### PR TITLE
Improved error messages

### DIFF
--- a/populace-core/src/main/java/org/datalorax/populace/core/walk/WalkerException.java
+++ b/populace-core/src/main/java/org/datalorax/populace/core/walk/WalkerException.java
@@ -16,11 +16,25 @@
 
 package org.datalorax.populace.core.walk;
 
+import org.datalorax.populace.core.walk.field.PathProvider;
+
 /**
  * @author Andrew Coates - 28/02/2015.
  */
 public class WalkerException extends RuntimeException {
-    public WalkerException(final String message, final Throwable cause) {
+    private final PathProvider path;
+
+    public WalkerException(final String message, final PathProvider path, final Throwable cause) {
         super(message, cause);
+        this.path = path;
+    }
+
+    public String getPath() {
+        return path.getPath();
+    }
+
+    @Override
+    public String getMessage() {
+        return super.getMessage() + " - Path: " + getPath();
     }
 }

--- a/populace-core/src/main/java/org/datalorax/populace/core/walk/field/FieldAccessException.java
+++ b/populace-core/src/main/java/org/datalorax/populace/core/walk/field/FieldAccessException.java
@@ -22,7 +22,7 @@ import org.datalorax.populace.core.walk.WalkerException;
  * @author Andrew Coates - 04/03/2015.
  */
 public class FieldAccessException extends WalkerException {
-    public FieldAccessException(final RawField field, final String path, final Throwable cause) {
-        super(String.format("Failed to access field: " + field + ", with path: " + path), cause);
+    public FieldAccessException(final RawField field, final PathProvider path, final Throwable cause) {
+        super(String.format("Failed to access field: " + field), path, cause);
     }
 }

--- a/populace-core/src/main/java/org/datalorax/populace/core/walk/field/FieldInfo.java
+++ b/populace-core/src/main/java/org/datalorax/populace/core/walk/field/FieldInfo.java
@@ -65,7 +65,7 @@ public class FieldInfo {
         try {
             return field.getValue(getOwningInstance());
         } catch (ReflectiveOperationException e) {
-            throw new FieldAccessException(field, path.getPath(), e);
+            throw new FieldAccessException(field, path, e);
         }
     }
 
@@ -73,7 +73,7 @@ public class FieldInfo {
         try {
             field.setValue(getOwningInstance(), value);
         } catch (ReflectiveOperationException e) {
-            throw new FieldAccessException(field, path.getPath(), e);
+            throw new FieldAccessException(field, path, e);
         }
     }
 

--- a/populace-core/src/test/java/org/datalorax/populace/core/walk/GraphWalkerFunctionalTest.java
+++ b/populace-core/src/test/java/org/datalorax/populace/core/walk/GraphWalkerFunctionalTest.java
@@ -34,8 +34,11 @@ import java.util.List;
 import java.util.Map;
 
 import static org.datalorax.populace.core.walk.field.FieldInfoMatcher.hasField;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.*;
+import static org.testng.Assert.fail;
 
 public class GraphWalkerFunctionalTest {
     private GraphWalker walker;
@@ -188,6 +191,22 @@ public class GraphWalkerFunctionalTest {
     public void shouldThrowOnVisitingPrivateFieldIfNothingSetsAccessible() throws Exception {
         // When:
         walker.walk(new TypeWithPrivateField(), visitor);
+    }
+
+    @Test
+    public void shouldIncludePathInExceptions() throws Exception {
+        // Given:
+        doThrow(new RuntimeException()).when(visitor).visit(any(FieldInfo.class));
+
+        // When:
+        try {
+            walker.walk(new TypeWithNestedObject(), visitor);
+            fail("should of thrown exception");
+        } catch (WalkerException e) {
+            // Then:
+            assertThat(e.getPath(), containsString("TypeWithNestedObject._nested"));
+            assertThat(e.toString(), containsString("TypeWithNestedObject._nested"));
+        }
     }
 
     @Test


### PR DESCRIPTION
Improve error reporting:

Exceptions thrown from graph walking should include the path down the object graph to the point the exception was thrown.

Exceptions thrown because no valid constructor could be found should include details of what constructors could be found.

Additionally, improved logging within the graph walker.
