### PR TITLE
Feature/pop 38 support for runtime generic type resolution

### DIFF
--- a/populace-core/src/main/java/org/datalorax/populace/core/populate/GraphPopulatorBuilder.java
+++ b/populace-core/src/main/java/org/datalorax/populace/core/populate/GraphPopulatorBuilder.java
@@ -42,7 +42,7 @@ final class GraphPopulatorBuilder implements GraphPopulator.Builder {
     private GraphWalker.Builder walkerBuilder = GraphWalker.newBuilder()
         .withFieldFilter(DEFAULT_FIELD_FILTER)
         .withInspectors(Inspectors.newBuilder()
-            .withSuperInspector(Collection.class, LoggingCollectionInspector.INSTANCE)  // Log on immutable elements // Todo(ac): Still needed?
+            .withSuperInspector(Collection.class, LoggingCollectionInspector.INSTANCE)  // Log on immutable elements
             .build());
 
     @Override

--- a/populace-core/src/main/java/org/datalorax/populace/core/populate/mutator/change/ChangePrimitiveMutator.java
+++ b/populace-core/src/main/java/org/datalorax/populace/core/populate/mutator/change/ChangePrimitiveMutator.java
@@ -78,5 +78,3 @@ public class ChangePrimitiveMutator implements Mutator {
         return getClass().getSimpleName();
     }
 }
-
-// Todo(ac): add generics e.g. NumberMutator<Number>

--- a/populace-core/src/main/java/org/datalorax/populace/core/util/TypeResolver.java
+++ b/populace-core/src/main/java/org/datalorax/populace/core/util/TypeResolver.java
@@ -1,0 +1,214 @@
+/*
+ * Copyright (c) 2015 Andrew Coates
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.datalorax.populace.core.util;
+
+import com.google.common.reflect.TypeToken;
+import org.apache.commons.lang3.Validate;
+import org.datalorax.populace.core.walk.field.TypeTable;
+
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.lang.reflect.TypeVariable;
+import java.util.Optional;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+
+/**
+ * @author Andrew Coates - 02/04/2015.
+ */
+// Todo(ac): Needs a refactor and a test, plus extension for wild cards, bounded, generic array types.
+public class TypeResolver {
+    private final TypeTable typeTable;
+
+    /**
+     * Creates a resolver that will use the type available in the supplied {@code typeTable} to resolve types
+     *
+     * @param typeTable the type table to use to resolve type variables
+     */
+    public TypeResolver(final TypeTable typeTable) {
+        Validate.notNull(typeTable, "typeTable null");
+        this.typeTable = typeTable;
+    }
+
+    /**
+     * Get a stream of all available aliases for the provided type variable found in any super types or implemented
+     * generic interfaces of the provided {@code type}
+     *
+     * @param typeVar the type variable to find aliases for
+     * @param type    the type whose super classes and interfaces to search for matching type variables
+     * @return the type argument of any matching type variables found.
+     */
+    private static Stream<TypeVariable<?>> findSuperAndInterfaceTypeArgumentAliases(final TypeVariable<?> typeVar,
+                                                                                    final TypeToken<?> type) {
+        return type.getTypes().stream()
+            .filter(t -> t.getType() instanceof ParameterizedType)      // Ignore non-parameterized types
+            .flatMap(t -> getTypeArgumentAliases(typeVar, t));    // For each parameterised get type argument aliases
+    }
+
+    /**
+     * Get a stream of available alias for the provided type variable e.g. given a type:
+     * <pre>
+     * {@code
+     *    interface SomeInterface&lt;T2&gt; {}
+     *    class SomeType&lt;T2&gt; implements SomeInterface&lt;T2&gt; {}
+     *
+     *    TypeVariable<?> typeVariable = SomeType.class.getTypeParameters()[0];
+     *    TypeToken interfaceToken = findTypeToken(TypeToken.of(SomeType.class).getTypes(), SomeInterface.class);
+     *    getTypeArgumentAliases(typeVariable, interfaceToken);
+     * }
+     * </pre>
+     * <p>
+     * will return a stream containing T2.
+     *
+     * @param typeVar the type variable to find an alias for
+     * @param type    the type token to search for matching type variables
+     * @return the type argument of any matching type variables found.
+     */
+    private static Stream<TypeVariable<?>> getTypeArgumentAliases(final TypeVariable<?> typeVar,
+                                                                  final TypeToken<?> type) {
+        Validate.isInstanceOf(ParameterizedType.class, type.getType());
+        final Type[] sourceTypeArgs = ((ParameterizedType) type.getType()).getActualTypeArguments();
+        final TypeVariable<? extends Class<?>>[] sourceAliases = type.getRawType().getTypeParameters();
+
+        return IntStream.range(0, sourceTypeArgs.length)
+            .filter(i -> sourceTypeArgs[i].equals(typeVar))  // Filter out indexes with different type argument
+            .filter(i -> !sourceAliases[i].equals(typeVar))  // Filter out aliases that match existing
+            .mapToObj(i -> sourceAliases[i]);                        // Return aliases
+    }
+
+    /**
+     * Resolve the provided {@code type} using the type information available
+     * <p>
+     * if {@code type} is a {@link Class} with type parameters, then it will return a {@link ParameterizedType} where the
+     * type parameters have been as resolved as much as is possible.
+     * <p>
+     * if {@code type} is a {@link Class} without type parameters, then the class is returned unchanged.
+     * <p>
+     * if {@code type} is a {@link ParameterizedType}, then it will return the parameterized type with its type parameters
+     * resolved as much as is possible.
+     *
+     * @param type the type to resolve
+     * @return the resolved type.
+     */
+    public Type resolve(final Type type) {
+        if (type instanceof Class) {
+            return resolveClass((Class<?>) type);
+        }
+        if (type instanceof ParameterizedType) {
+            return resolveParameterisedType(type);
+        }
+
+        // Todo(ac):
+        return type;
+    }
+
+    private Type resolveClass(final Class<?> type) {
+        final TypeVariable<? extends Class<?>>[] typeParameters = type.getTypeParameters();
+        if (typeParameters.length == 0) {
+            return type;
+        }
+
+        final ParameterizedType parameterised = TypeUtils.parameterise(type, typeParameters);
+        return resolveParameterisedType(parameterised);
+    }
+
+    private Type resolveParameterisedType(final Type type) {
+        final TypeToken<?> typeToken = TypeToken.of(type);
+        final ParameterizedType pt = (ParameterizedType) typeToken.getType();
+        final Type[] typeArgs = pt.getActualTypeArguments();
+        final Type[] resolvedArgs = new Type[typeArgs.length];
+
+        for (int i = 0; i != typeArgs.length; ++i) {
+            final Type typeArg = typeArgs[i];
+            resolvedArgs[i] = typeArg;
+            if (typeArg instanceof Class) {
+                continue;
+            }
+
+            Optional<Type> resolved = resolveToNew(typeArg);
+            if (resolved.isPresent()) {
+                resolvedArgs[i] = resolved.get();
+                continue;
+            }
+
+            if (!(typeArg instanceof TypeVariable)) {
+                throw new UnsupportedOperationException();
+            }
+
+            resolved = resolveTypeVariable((TypeVariable<?>) typeArg, typeToken);
+
+            if (resolved.isPresent()) {
+                resolvedArgs[i] = resolved.get();
+            }
+        }
+
+        return TypeUtils.parameterise(typeToken.getRawType(), resolvedArgs);
+    }
+
+    private Type resolveType(final Type genericType) {
+        if (genericType instanceof Class) {
+            return genericType;
+        }
+
+        if (genericType instanceof ParameterizedType) {
+            final Type[] typeArgs = ((ParameterizedType) genericType).getActualTypeArguments();
+            for (int i = 0; i != typeArgs.length; ++i) {
+                typeArgs[i] = resolveType(typeArgs[i]);
+            }
+
+            return TypeUtils.parameterise((Class) ((ParameterizedType) genericType).getRawType(), typeArgs);
+        }
+
+        if (genericType instanceof TypeVariable) {
+            final Type type = typeTable.resolveTypeVariable((TypeVariable) genericType);
+            if (type.equals(genericType)) {
+                return type;
+            }
+
+            return resolveType(type);
+        }
+
+        return null;
+    }
+
+    /**
+     * Resolve the provided {@code type} using the supplied {@code typeTable}.
+     *
+     * @param type the type to resolve
+     * @return the resolved type or Optional.empty() if the type could not be resolved.
+     */
+    private Optional<Type> resolveToNew(final Type type) {
+        final Type resolved = resolveType(type);
+        return type.equals(resolved) ? Optional.empty() : Optional.of(resolved);
+    }
+
+    /**
+     * Resolved to provided {@code typeVar}, for the provided {@code type}, using the provided {@code typeTable}
+     *
+     * @param typeVar the type variable to resolve
+     * @param type    the type the variable belongs to.
+     * @return the resolved type, or Optional.empty() if the type couldn't be resolved.
+     */
+    private Optional<Type> resolveTypeVariable(final TypeVariable<?> typeVar, final TypeToken<?> type) {
+        final Stream<TypeVariable<?>> typeArgAliases = findSuperAndInterfaceTypeArgumentAliases(typeVar, type);
+        return typeArgAliases
+            .map(this::resolveToNew)
+            .filter(Optional::isPresent)
+            .map(Optional::get)
+            .findFirst();
+    }
+}

--- a/populace-core/src/main/java/org/datalorax/populace/core/util/TypeResolver.java
+++ b/populace-core/src/main/java/org/datalorax/populace/core/util/TypeResolver.java
@@ -58,6 +58,8 @@ public class TypeResolver {
      * @return the resolved type.
      */
     public Type resolve(final Type type) {
+        Validate.notNull(type, "type null");
+
         if (type instanceof Class) {
             return resolveClass((Class<?>) type);
         }

--- a/populace-core/src/main/java/org/datalorax/populace/core/walk/GraphWalker.java
+++ b/populace-core/src/main/java/org/datalorax/populace/core/walk/GraphWalker.java
@@ -129,7 +129,7 @@ public class GraphWalker {
 
         for (RawField field : fields) {
             final WalkerStack fieldStack = instanceStack.push(field);
-            final FieldInfo fieldInfo = new FieldInfo(field, instance, fieldStack, fieldStack);
+            final FieldInfo fieldInfo = new FieldInfo(field, instance, fieldStack.getTypeResolver(), fieldStack);
 
             if (context.isExcludedField(fieldInfo)) {
                 logDebug("Skipping excluded field: " + fieldInfo.getName(), fieldStack);
@@ -161,7 +161,7 @@ public class GraphWalker {
         while (elements.hasNext()) {
             final RawElement element = elements.next();
             final WalkerStack elementStack = stack.push(element);
-            final ElementInfo elementInfo = new ElementInfo(element, containerType, elementStack, elementStack);
+            final ElementInfo elementInfo = new ElementInfo(element, containerType, elementStack.getTypeResolver(), elementStack);
 
             logInfo("Visiting element: " + elementInfo, elementStack);
 

--- a/populace-core/src/main/java/org/datalorax/populace/core/walk/GraphWalker.java
+++ b/populace-core/src/main/java/org/datalorax/populace/core/walk/GraphWalker.java
@@ -66,18 +66,6 @@ public class GraphWalker {
         return new GraphWalkerBuilder();
     }
 
-    private static void logDebug(String message, PathProvider path) {
-        if (LOG.isDebugEnabled()) {
-            LOG.debug(path.getPath() + " - " + message);
-        }
-    }
-
-    private static void logInfo(String message, PathProvider path) {
-        if (LOG.isInfoEnabled()) {
-            LOG.info(path.getPath() + " - " + message);
-        }
-    }
-
     /**
      * Recursively walk the fields on {@code instance} and any objects it links too, calling back on {@code fieldVisitor}
      * for each field as it is discovered and {@code elementVisitor} for each child element of each collection field.
@@ -114,7 +102,8 @@ public class GraphWalker {
     }
 
     private void walk(final Type type, final Object instance, final Visitors visitors, final WalkerStack stack) {
-        final Inspector inspector = context.getInspector(instance.getClass());  // Todo(Ac): Do inspectors support generic types or not? Should TYpedCollection take type? Or overloaded Class/ParameterisedType versions
+        final Type resolvedType = stack.getTypeResolver().resolve(instance.getClass());
+        final Inspector inspector = context.getInspector(resolvedType);
         logInfo("Walking type: " + abbreviatedName(type) + ", inspector: " + abbreviatedName(inspector.getClass()), stack);
 
         walkFields(instance, visitors, inspector, stack);
@@ -181,6 +170,18 @@ public class GraphWalker {
             }
 
             element.postWalk();
+        }
+    }
+
+    private static void logDebug(String message, PathProvider path) {
+        if (LOG.isDebugEnabled()) {
+            LOG.debug(path.getPath() + " - " + message);
+        }
+    }
+
+    private static void logInfo(String message, PathProvider path) {
+        if (LOG.isInfoEnabled()) {
+            LOG.info(path.getPath() + " - " + message);
         }
     }
 

--- a/populace-core/src/main/java/org/datalorax/populace/core/walk/WalkerStack.java
+++ b/populace-core/src/main/java/org/datalorax/populace/core/walk/WalkerStack.java
@@ -90,13 +90,13 @@ public abstract class WalkerStack implements PathProvider, TypeTable {
         }
 
         @Override
-        protected String getToken() {
-            return root.getClass().getSimpleName();
+        public Type resolveTypeVariable(final TypeVariable variable) {
+            return variable;    // Not enough type information to resolve
         }
 
         @Override
-        public Type resolveTypeVariable(final TypeVariable variable) {
-            return variable;    // Not enough type information to resolve
+        protected String getToken() {
+            return root.getClass().getSimpleName();
         }
     }
 
@@ -111,11 +111,6 @@ public abstract class WalkerStack implements PathProvider, TypeTable {
         }
 
         @Override
-        protected String getToken() {
-            return '.' + field.getName();
-        }
-
-        @Override
         public Type resolveTypeVariable(final TypeVariable variable) {
             final TypeToken<?> typeToken = type.resolveType(variable);
             if (typeToken.getType().equals(variable)) {
@@ -123,21 +118,11 @@ public abstract class WalkerStack implements PathProvider, TypeTable {
             }
 
             return typeToken.getType();
+        }
 
-            // Todo(ac):
-//            final Type genericType = field.getGenericType();
-//            if (genericType instanceof ParameterizedType) {
-//                ParameterizedType parameterizedType = (ParameterizedType)genericType;
-//                final Type[] typeArgs = parameterizedType.getActualTypeArguments();
-//                final TypeVariable<? extends Class<?>>[] typeVars = ((Class<?>) parameterizedType.getRawType()).getTypeParameters();
-//
-//                for (int i = 0; i != typeArgs.length; ++i) {
-//                    if (typeVars[i].equals(variable)) {
-//                        return resolveType(typeArgs[i]);
-//                    }
-//                }
-//            }
-//            return getParent().resolveTypeVariable(variable);
+        @Override
+        protected String getToken() {
+            return '.' + field.getName();
         }
     }
 
@@ -150,13 +135,13 @@ public abstract class WalkerStack implements PathProvider, TypeTable {
         }
 
         @Override
-        protected String getToken() {
-            return "[" + element.getClass().getSimpleName() + "]";
+        public Type resolveTypeVariable(final TypeVariable variable) {
+            return getParent().resolveTypeVariable(variable);
         }
 
         @Override
-        public Type resolveTypeVariable(final TypeVariable variable) {
-            return getParent().resolveTypeVariable(variable);
+        protected String getToken() {
+            return "[" + element.getClass().getSimpleName() + "]";
         }
     }
 }

--- a/populace-core/src/main/java/org/datalorax/populace/core/walk/element/ElementInfo.java
+++ b/populace-core/src/main/java/org/datalorax/populace/core/walk/element/ElementInfo.java
@@ -47,7 +47,7 @@ public class ElementInfo {
      * @see org.datalorax.populace.core.walk.element.RawElement#getGenericType(java.lang.reflect.Type)
      */
     public Type getGenericType() {
-        // Todo(ac): get from value?
+        // Todo(ac): get from value elements.
         return typeResolver.resolve(element.getGenericType(containerType));
     }
 

--- a/populace-core/src/main/java/org/datalorax/populace/core/walk/element/ElementInfo.java
+++ b/populace-core/src/main/java/org/datalorax/populace/core/walk/element/ElementInfo.java
@@ -17,7 +17,7 @@
 package org.datalorax.populace.core.walk.element;
 
 import org.apache.commons.lang3.Validate;
-import org.datalorax.populace.core.walk.field.GenericTypeResolver;
+import org.datalorax.populace.core.util.TypeResolver;
 import org.datalorax.populace.core.walk.field.PathProvider;
 
 import java.lang.reflect.Type;
@@ -27,11 +27,11 @@ import java.lang.reflect.Type;
  */
 public class ElementInfo {
     private final RawElement element;
-    private final GenericTypeResolver typeResolver;
+    private final TypeResolver typeResolver;
     private final PathProvider path;
     private final Type containerType;
 
-    public ElementInfo(final RawElement element, final Type containerType, final GenericTypeResolver typeResolver, final PathProvider path) {
+    public ElementInfo(final RawElement element, final Type containerType, final TypeResolver typeResolver, final PathProvider path) {
         Validate.notNull(element, "field null");
         Validate.notNull(containerType, "field containerType");
         Validate.notNull(typeResolver, "typeResolver null");
@@ -47,7 +47,8 @@ public class ElementInfo {
      * @see org.datalorax.populace.core.walk.element.RawElement#getGenericType(java.lang.reflect.Type)
      */
     public Type getGenericType() {
-        return typeResolver.resolveType(element.getGenericType(containerType));
+        // Todo(ac): get from value?
+        return typeResolver.resolve(element.getGenericType(containerType));
     }
 
     /**

--- a/populace-core/src/main/java/org/datalorax/populace/core/walk/field/FieldInfo.java
+++ b/populace-core/src/main/java/org/datalorax/populace/core/walk/field/FieldInfo.java
@@ -17,6 +17,7 @@
 package org.datalorax.populace.core.walk.field;
 
 import org.apache.commons.lang3.Validate;
+import org.datalorax.populace.core.util.TypeResolver;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
@@ -27,10 +28,10 @@ import java.lang.reflect.Type;
 public class FieldInfo {
     private final RawField field;
     private final Object owningInstance;
-    private final GenericTypeResolver typeResolver;
+    private final TypeResolver typeResolver;
     private final PathProvider path;
 
-    public FieldInfo(final RawField field, final Object owningInstance, final GenericTypeResolver typeResolver, final PathProvider path) {
+    public FieldInfo(final RawField field, final Object owningInstance, final TypeResolver typeResolver, final PathProvider path) {
         Validate.notNull(field, "field null");
         Validate.notNull(owningInstance, "owningInstance null");
         Validate.notNull(typeResolver, "typeResolver null");
@@ -70,7 +71,13 @@ public class FieldInfo {
      * @see RawField#getGenericType()
      */
     public Type getGenericType() {
-        return typeResolver.resolveType(field.getGenericType());
+        // Todo(ac):
+        final Object value = getValue();
+        if (value != null) {
+            final Class<?> type = field.getType().isPrimitive() ? field.getType() : value.getClass();
+            return typeResolver.resolve(type);
+        }
+        return typeResolver.resolve(field.getGenericType());
     }
 
     /**
@@ -159,17 +166,12 @@ public class FieldInfo {
         if (o == null || getClass() != o.getClass()) return false;
 
         final FieldInfo that = (FieldInfo) o;
-        return field.equals(that.field) && owningInstance.equals(that.owningInstance)
-            && path.equals(that.path) && typeResolver.equals(that.typeResolver);
+        return path.equals(that.path);
     }
 
     @Override
     public int hashCode() {
-        int result = field.hashCode();
-        result = 31 * result + owningInstance.hashCode();
-        result = 31 * result + typeResolver.hashCode();
-        result = 31 * result + path.hashCode();
-        return result;
+        return path.hashCode();
     }
 
     @Override

--- a/populace-core/src/main/java/org/datalorax/populace/core/walk/field/FieldInfo.java
+++ b/populace-core/src/main/java/org/datalorax/populace/core/walk/field/FieldInfo.java
@@ -71,7 +71,6 @@ public class FieldInfo {
      * @see RawField#getGenericType()
      */
     public Type getGenericType() {
-        // Todo(ac):
         final Object value = getValue();
         if (value != null) {
             final Class<?> type = field.getType().isPrimitive() ? field.getType() : value.getClass();

--- a/populace-core/src/main/java/org/datalorax/populace/core/walk/field/TypeTable.java
+++ b/populace-core/src/main/java/org/datalorax/populace/core/walk/field/TypeTable.java
@@ -17,10 +17,11 @@
 package org.datalorax.populace.core.walk.field;
 
 import java.lang.reflect.Type;
+import java.lang.reflect.TypeVariable;
 
 /**
  * @author Andrew Coates - 12/03/2015.
  */
-public interface GenericTypeResolver {
-    Type resolveType(final Type genericType);
+public interface TypeTable {
+    Type resolveTypeVariable(final TypeVariable variable);
 }

--- a/populace-core/src/main/java/org/datalorax/populace/core/walk/inspector/CollectionInspector.java
+++ b/populace-core/src/main/java/org/datalorax/populace/core/walk/inspector/CollectionInspector.java
@@ -38,20 +38,6 @@ public class CollectionInspector implements Inspector {
     private static final TypeVariable<Class<Collection>> COLLECTION_TYPE_VARIABLE = Collection.class.getTypeParameters()[0];
 
     @SuppressWarnings("unchecked")
-    private static Collection<?> ensureCollection(final Object instance) {
-        Validate.isInstanceOf(Collection.class, instance);
-        Validate.isTrue(!Set.class.isAssignableFrom(instance.getClass()), "Set types are not supported");
-        return (Collection<?>) instance;
-    }
-
-    private static Iterator<RawElement> toRawElements(final Collection<?> collection) {
-        final List<RawElement> elements = collection.stream()
-            .map(CollectionElement::new)
-            .collect(Collectors.toList());
-        return elements.iterator();
-    }
-
-    @SuppressWarnings("unchecked")
     @Override
     public Iterator<RawElement> getElements(final Object instance, final Inspectors inspectors) {
         final Collection<?> collection = ensureCollection(instance);
@@ -71,6 +57,20 @@ public class CollectionInspector implements Inspector {
     @Override
     public String toString() {
         return getClass().getSimpleName();
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Collection<?> ensureCollection(final Object instance) {
+        Validate.isInstanceOf(Collection.class, instance);
+        Validate.isTrue(!Set.class.isAssignableFrom(instance.getClass()), "Set types are not supported");
+        return (Collection<?>) instance;
+    }
+
+    private static Iterator<RawElement> toRawElements(final Collection<?> collection) {
+        final List<RawElement> elements = collection.stream()
+            .map(CollectionElement::new)
+            .collect(Collectors.toList());
+        return elements.iterator();
     }
 
     private static class CollectionElement implements RawElement {
@@ -96,7 +96,6 @@ public class CollectionInspector implements Inspector {
                 "Likely cause of this exception is an unsupported collection type containing an immutable object.\n" +
                 "Consider adding a custom inspector that knows how to replace entries within the custom collection type\n" +
                 "Or switch to a logging or terminal inspector for the collection type.");
-            // Todo(ac): error message is populate-centric, not walk-centric...
         }
     }
 }

--- a/populace-core/src/test/java/org/datalorax/populace/core/CustomCollection.java
+++ b/populace-core/src/test/java/org/datalorax/populace/core/CustomCollection.java
@@ -25,8 +25,8 @@ import java.util.List;
  * @author Andrew Coates - 30/03/2015.
  */
 @SuppressWarnings("NullableProblems")
-public class CustomCollection<E> implements Collection<E> {
-    private final List<E> elements = new ArrayList<>();
+public class CustomCollection<ET> implements Collection<ET> {
+    private final List<ET> elements = new ArrayList<>();
 
     @Override
     public int size() {
@@ -44,7 +44,7 @@ public class CustomCollection<E> implements Collection<E> {
     }
 
     @Override
-    public Iterator<E> iterator() {
+    public Iterator<ET> iterator() {
         return elements.iterator();
     }
 
@@ -53,14 +53,15 @@ public class CustomCollection<E> implements Collection<E> {
         return elements.toArray();
     }
 
+    @SuppressWarnings("SuspiciousToArrayCall")
     @Override
     public <T> T[] toArray(final T[] a) {
         return elements.toArray(a);
     }
 
     @Override
-    public boolean add(final E e) {
-        return elements.add(e);
+    public boolean add(final ET ET) {
+        return elements.add(ET);
     }
 
     @Override
@@ -74,7 +75,7 @@ public class CustomCollection<E> implements Collection<E> {
     }
 
     @Override
-    public boolean addAll(final Collection<? extends E> c) {
+    public boolean addAll(final Collection<? extends ET> c) {
         return elements.addAll(c);
     }
 

--- a/populace-core/src/test/java/org/datalorax/populace/core/util/TypeResolverTest.java
+++ b/populace-core/src/test/java/org/datalorax/populace/core/util/TypeResolverTest.java
@@ -1,0 +1,165 @@
+/*
+ * Copyright (c) 2015 Andrew Coates
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.datalorax.populace.core.util;
+
+import org.datalorax.populace.core.walk.field.TypeTable;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.lang.reflect.Type;
+import java.lang.reflect.TypeVariable;
+import java.util.Collection;
+import java.util.Map;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@SuppressWarnings("UnusedDeclaration")
+public class TypeResolverTest {
+    private TypeResolver resolver;
+    private TypeTable typeTable;
+
+    @BeforeMethod
+    public void setUp() throws Exception {
+        typeTable = mock(TypeTable.class);
+        resolver = new TypeResolver(typeTable);
+
+        // By default, just type table can't resolve anything:
+        when(typeTable.resolveTypeVariable(any(TypeVariable.class))).thenAnswer(invocation -> invocation.getArguments()[0]);
+    }
+
+    @Test(expectedExceptions = NullPointerException.class)
+    public void shouldThrowOnNullArg() throws Exception {
+        new TypeResolver(null);
+    }
+
+    @Test
+    public void shouldReturnRawUnparameterisedClassUntouched() throws Exception {
+        assertThat(resolver.resolve(String.class), is(equalTo((Type) String.class)));
+    }
+
+    @Test
+    public void shouldReturnParameterisedClassWithTypeVariablesIfItCantResolveThem() throws Exception {
+        assertThat(resolver.resolve(Map.class), is((Type) TypeUtils.parameterise(Map.class, Map.class.getTypeParameters())));
+    }
+
+    @Test
+    public void shouldPartiallyResolveParameterisedClass() throws Exception {
+        // Given:
+        when(typeTable.resolveTypeVariable(Map.class.getTypeParameters()[0])).thenReturn(String.class);
+
+        // Then:
+        assertThat(resolver.resolve(Map.class), is((Type) TypeUtils.parameterise(Map.class, String.class, Map.class.getTypeParameters()[1])));
+    }
+
+    @Test
+    public void shouldFullyResolveParameterisedClass() throws Exception {
+        // Given:
+        when(typeTable.resolveTypeVariable(Map.class.getTypeParameters()[0])).thenReturn(String.class);
+        when(typeTable.resolveTypeVariable(Map.class.getTypeParameters()[1])).thenReturn(Integer.class);
+
+        // Then:
+        assertThat(resolver.resolve(Map.class), is((Type) TypeUtils.parameterise(Map.class, String.class, Integer.class)));
+    }
+
+    @Test
+    public void shouldResolveUsingInheritedInterfaceGenericInfo() throws Exception {
+        // Given:
+        class SomeType<T> implements SomeInterface<T> {
+        }
+
+        when(typeTable.resolveTypeVariable(SomeInterface.class.getTypeParameters()[0])).thenReturn(Number.class);
+
+        // Then:
+        assertThat(resolver.resolve(SomeType.class), is(TypeUtils.parameterise(SomeType.class, Number.class)));
+    }
+
+    @Test
+    public void shouldResolveUsingSuperClassGenericInfo() throws Exception {
+        // Given:
+        class SuperClass<ST> {
+        }
+        class SomeType<T> extends SuperClass<T> {
+        }
+
+        when(typeTable.resolveTypeVariable(SuperClass.class.getTypeParameters()[0])).thenReturn(Number.class);
+
+        // Then:
+        assertThat(resolver.resolve(SomeType.class), is(TypeUtils.parameterise(SomeType.class, Number.class)));
+    }
+
+    @Test
+    public void shouldNotUseUnrelatedSuperInterfaceTypeVariables() throws Exception {
+        // Given:
+        class SomeType<T> implements SomeInterface<String> {
+        }
+
+        when(typeTable.resolveTypeVariable(SomeInterface.class.getTypeParameters()[0])).thenReturn(String.class);
+
+        // Then:
+        assertThat(resolver.resolve(SomeType.class), is(TypeUtils.parameterise(SomeType.class, SomeType.class.getTypeParameters())));
+    }
+
+    @Test
+    public void shouldNotUseUnresolveSuperClassTypeVariables() throws Exception {
+        // Given:
+        class SuperClass<ST> {
+        }
+        class SomeType<T> extends SuperClass<String> {
+        }
+
+        when(typeTable.resolveTypeVariable(SuperClass.class.getTypeParameters()[0])).thenReturn(String.class);
+
+        // Then:
+        assertThat(resolver.resolve(SomeType.class), is(TypeUtils.parameterise(SomeType.class, SomeType.class.getTypeParameters())));
+    }
+
+    @Test
+    public void shouldWorkWithBoundedTypeVariable() throws Exception {
+        // Given:
+        class SuperClass<ST extends Number> {
+        }
+        class SomeType<T extends Number> extends SuperClass<T> {
+        }
+
+        when(typeTable.resolveTypeVariable(SuperClass.class.getTypeParameters()[0])).thenReturn(Integer.class);
+
+        // Then:
+        assertThat(resolver.resolve(SomeType.class), is(TypeUtils.parameterise(SomeType.class, Integer.class)));
+    }
+
+    @Test(enabled = false)
+    public void shouldWorkWithWildCards() throws Exception {
+        // Given:
+        class SomeType {
+            Collection<?> field;
+        }
+        final Type typeWithWildcard = SomeType.class.getDeclaredField("field").getGenericType();
+
+        // Then:
+        assertThat(resolver.resolve(typeWithWildcard), is(TypeUtils.parameterise(SomeType.class, Integer.class)));
+    }
+
+    // Todo(ac): wildcards, generic arrays, etc.
+
+    interface SomeInterface<E> {
+    }
+}

--- a/populace-core/src/test/java/org/datalorax/populace/core/walk/field/FieldInfoTest.java
+++ b/populace-core/src/test/java/org/datalorax/populace/core/walk/field/FieldInfoTest.java
@@ -1,0 +1,359 @@
+/*
+ * Copyright (c) 2015 Andrew Coates
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.datalorax.populace.core.walk.field;
+
+import org.datalorax.populace.core.util.TypeResolver;
+import org.datalorax.populace.core.util.TypeUtils;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.lang.reflect.Type;
+import java.util.Map;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyObject;
+import static org.mockito.Mockito.*;
+
+public class FieldInfoTest {
+    private FieldInfo fieldInfo;
+    @Mock
+    private RawField field;
+    @Mock
+    private Object owningInstance;
+    @Mock
+    private TypeResolver typeResolver;
+    @Mock
+    private PathProvider pathProvider;
+    private Type genericType;
+
+    @BeforeMethod
+    public void setUp() throws Exception {
+        MockitoAnnotations.initMocks(this);
+
+        genericType = TypeUtils.parameterise(Map.class, Map.class.getTypeParameters());
+
+        fieldInfo = new FieldInfo(field, owningInstance, typeResolver, pathProvider);
+    }
+
+    @Test
+    public void shouldGetNameFromField() throws Exception {
+        // Given:
+        when(field.getName()).thenReturn("bob");
+
+        // When:
+        final String name = fieldInfo.getName();
+
+        // Then:
+        assertThat(name, is("bob"));
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void shouldGetDeclaringClassFromField() throws Exception {
+        // Given:
+        when(field.getDeclaringClass()).thenReturn((Class) this.getClass());
+
+        // When:
+        final Class<?> type = fieldInfo.getDeclaringClass();
+
+        // Then:
+        assertThat(type, is(equalTo(this.getClass())));
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void shouldGetTypeFromField() throws Exception {
+        // Given:
+        when(field.getType()).thenReturn((Class) this.getClass());
+
+        // When:
+        final Class<?> type = fieldInfo.getType();
+
+        // Then:
+        assertThat(type, is(equalTo(this.getClass())));
+    }
+
+    @Test
+    public void shouldGetValueFromField() throws Exception {
+        // Given:
+        when(field.getValue(anyObject())).thenReturn("expected");
+
+        // When:
+        final Object value = fieldInfo.getValue();
+
+        // Then:
+        assertThat(value, is("expected"));
+    }
+
+    @Test
+    public void shouldPassOwningInstanceWhenGettingValue() throws Exception {
+        // Given:
+        when(field.getValue(anyObject())).thenReturn("expected");
+
+        // When:
+        fieldInfo.getValue();
+
+        // Then:
+        verify(field).getValue(owningInstance);
+    }
+
+    @Test(expectedExceptions = FieldAccessException.class)
+    public void shouldThrowFieldAccessExceptionIfNoAccessWhenGettingValue() throws Exception {
+        // Given:
+        when(field.getValue(anyObject())).thenThrow(new IllegalAccessException());
+
+        // When:
+        fieldInfo.getValue();
+    }
+
+    @Test
+    public void shouldSetValueOnField() throws Exception {
+        // When:
+        fieldInfo.setValue("expected");
+
+        // Then:
+        verify(field).setValue(anyObject(), eq("expected"));
+    }
+
+    @Test
+    public void shouldPassOwningInstanceWhenSettingValue() throws Exception {
+        // When:
+        fieldInfo.setValue(this);
+
+        // Then:
+        verify(field).setValue(eq(owningInstance), anyObject());
+    }
+
+    @Test(expectedExceptions = FieldAccessException.class)
+    public void shouldThrowFieldAccessExceptionIfNoAccessWhenSettingValue() throws Exception {
+        // Given:
+        doThrow(new IllegalAccessException()).when(field).setValue(anyObject(), anyObject());
+
+        // When:
+        fieldInfo.setValue(this);
+    }
+
+    @Test
+    public void shouldGetAnnotationFromField() throws Exception {
+        // Given:
+        final Test expected = getClass().getMethod("shouldGetAnnotationFromField").getAnnotation(Test.class);
+        when(field.getAnnotation(Test.class)).thenReturn(expected);
+
+        // When:
+        final Test annotation = fieldInfo.getAnnotation(Test.class);
+
+        // Then:
+        assertThat(annotation, is(expected));
+    }
+
+    @Test
+    public void shouldGetTransientFlagFromField() throws Exception {
+        // Given:
+        when(field.isTransient()).thenReturn(true);
+
+        // When:
+        assertThat(fieldInfo.isTransient(), is(true));
+
+        // Given:
+        when(field.isTransient()).thenReturn(false);
+
+        // When:
+        assertThat(fieldInfo.isTransient(), is(false));
+    }
+
+    @Test
+    public void shouldGetStaticFlagFromField() throws Exception {
+        // Given:
+        when(field.isStatic()).thenReturn(true);
+
+        // When:
+        assertThat(fieldInfo.isStatic(), is(true));
+
+        // Given:
+        when(field.isStatic()).thenReturn(false);
+
+        // When:
+        assertThat(fieldInfo.isStatic(), is(false));
+    }
+
+    @Test
+    public void shouldGetFinalFlagFromField() throws Exception {
+        // Given:
+        when(field.isFinal()).thenReturn(true);
+
+        // When:
+        assertThat(fieldInfo.isFinal(), is(true));
+
+        // Given:
+        when(field.isFinal()).thenReturn(false);
+
+        // When:
+        assertThat(fieldInfo.isFinal(), is(false));
+    }
+
+    @Test
+    public void shouldReturnGenericTypeFromResolver() throws Exception {
+        // Given:
+        givenFieldHasValue("value");
+        when(typeResolver.resolve(any(Type.class))).thenReturn(genericType);
+
+        // When:
+        final Type genericType = fieldInfo.getGenericType();
+
+        // Then:
+        assertThat(genericType, is(genericType));
+    }
+
+    @Test
+    public void shouldGetGenericTypeFromFieldIfValueNull() throws Exception {
+        // Given:
+        givenFieldHasValue(null, Map.class);
+        when(field.getGenericType()).thenReturn(genericType);
+
+        // When:
+        fieldInfo.getGenericType();
+
+        // Then:
+        verify(typeResolver).resolve(genericType);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void shouldGetGenericTypeFromValueIfNotNull() throws Exception {
+        // Given:
+        givenFieldHasValue("value");
+
+        // When:
+        fieldInfo.getGenericType();
+
+        // Then:
+        verify(typeResolver).resolve(String.class);
+    }
+
+    @Test
+    public void shouldDetectPrimitiveGenericTypes() throws Exception {
+        // Given:
+        givenFieldHasValue(41L, long.class);
+
+        // When:
+        final Type result = fieldInfo.getGenericType();
+
+        // Then:
+        assertThat(result, is(equalTo((Type) long.class)));
+    }
+
+    @Test
+    public void shouldNotInvokeResolverForPrimitiveTypes() throws Exception {
+        // Given:
+        givenFieldHasValue(41L, long.class);
+
+        // When:
+        fieldInfo.getGenericType();
+
+        // Then:
+        verify(typeResolver, never()).resolve(any(Type.class));
+    }
+
+    @Test
+    public void shouldNotGetCurrentValueForPimitiveTypes() throws Exception {
+        // Given:
+        givenFieldHasValue(41L, long.class);
+
+        // When:
+        fieldInfo.getGenericType();
+
+        // Then:
+        verify(field, never()).getValue(anyObject());
+    }
+
+    @Test
+    public void shouldOnlyTakePathIntoAccountInEqualsAsPathIsUnique() throws Exception {
+        // Given:
+        when(pathProvider.getPath()).thenReturn("some/path");
+        final FieldInfo another = new FieldInfo(field, owningInstance, typeResolver, pathProvider);
+
+        // When:
+        final boolean result = fieldInfo.equals(another);
+
+        // Then:
+        verify(pathProvider, times(2)).getPath();
+        assertThat(result, is(true));
+        verifyNoMoreInteractions(field, typeResolver);
+    }
+
+    @Test
+    public void shouldNotBeEqualIfDifferentPaths() throws Exception {
+        // Given:
+        when(pathProvider.getPath()).thenReturn("some/path");
+        final PathProvider otherPath = mock(PathProvider.class);
+        when(otherPath.getPath()).thenReturn("different/path");
+        final FieldInfo another = new FieldInfo(field, owningInstance, typeResolver, otherPath);
+
+        // When:
+        final boolean result = fieldInfo.equals(another);
+
+        // Then:
+        assertThat(result, is(false));
+    }
+
+    @Test
+    public void shouldOnlyUsePathInHashCode() throws Exception {
+        // Given:
+        when(pathProvider.getPath()).thenReturn("some/path");
+
+        // When:
+        final int hashCode = fieldInfo.hashCode();
+
+        // Then:
+        assertThat(hashCode, is("some/path".hashCode()));
+    }
+
+    @Test
+    public void shouldIncludePathInToString() throws Exception {
+        // Given:
+        when(pathProvider.getPath()).thenReturn("some/path");
+
+        // When:
+        final String string = fieldInfo.toString();
+
+        // Then:
+        assertThat(string, containsString("some/path"));
+    }
+
+    @Test
+    public void shouldEnsureFieldAccessible() throws Exception {
+        // When:
+        fieldInfo.ensureAccessible();
+
+        // Then:
+        verify(field).ensureAccessible();
+    }
+
+    private void givenFieldHasValue(final Object value) throws IllegalAccessException {
+        givenFieldHasValue(value, value.getClass());
+    }
+
+    @SuppressWarnings("unchecked")
+    private void givenFieldHasValue(final Object value, Class type) throws IllegalAccessException {
+        when(field.getValue(anyObject())).thenReturn(value);
+        when(field.getType()).thenReturn(type);
+    }
+}


### PR DESCRIPTION
Fixed #38 - support for runtime generic types i.e. If you have a field of type Map<String, Number> and the value of that field is a HashMap, then the runtime generic type of the field is determined to be HashMap<String, Number>.

At present wildcard and generic arrays are not fully supported. See #39 which covers extending this support to wildcard and generic arrays.
