### PR TITLE
Feature/pop 46 improve test coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,8 @@ GraphPopulator populator = GraphPopulator.newBuilder().build();
 Contacts contacts = populator.populate(new Contacts());
 ```
 
+<!--- Todo(ac): Add intro to customisation, leading on to how it calculates runtime type info --->
+
 ### Known limitations
 #### `Collection` fields
 Due to the restrictions of the `Collection` API it is not possible to mutate collections of immutable types,

--- a/build.gradle
+++ b/build.gradle
@@ -18,6 +18,8 @@
 
 
 
+
+
 apply plugin: 'com.github.kt3k.coveralls'
 apply plugin: 'jacoco'
 
@@ -70,6 +72,7 @@ subprojects {
         testCompile group: 'org.hamcrest', name: 'hamcrest-all', version: '1.+'
         testCompile 'org.testng:testng:6.8.+'
         testCompile 'org.mockito:mockito-all:1.10.+'
+        testCompile 'com.google.guava:guava-testlib:18.+'
     }
 
     tasks.withType(JavaCompile) {

--- a/populace-core/src/main/java/org/datalorax/populace/core/populate/instance/DefaultTypeInstanceFactory.java
+++ b/populace-core/src/main/java/org/datalorax/populace/core/populate/instance/DefaultTypeInstanceFactory.java
@@ -51,10 +51,6 @@ public class DefaultTypeInstanceFactory implements InstanceFactory {
         this.concreteFactory = concreteFactory;
     }
 
-    private static boolean isConcrete(final Class<?> rawType) {
-        return !rawType.isInterface() && !Modifier.isAbstract(rawType.getModifiers());
-    }
-
     @Override
     public <T> T createInstance(final Class<? extends T> type, final Object parent, final InstanceFactories instanceFactories) {
         if (notSupported(type)) {
@@ -111,5 +107,9 @@ public class DefaultTypeInstanceFactory implements InstanceFactory {
     @SuppressWarnings("unchecked")
     private <T> T createDefaultType(final Object parent, final InstanceFactories instanceFactories) {
         return (T) concreteFactory.createInstance(defaultType, parent, instanceFactories);
+    }
+
+    private static boolean isConcrete(final Class<?> rawType) {
+        return !rawType.isInterface() && !Modifier.isAbstract(rawType.getModifiers());
     }
 }

--- a/populace-core/src/main/java/org/datalorax/populace/core/populate/instance/EnumInstanceFactory.java
+++ b/populace-core/src/main/java/org/datalorax/populace/core/populate/instance/EnumInstanceFactory.java
@@ -25,13 +25,9 @@ package org.datalorax.populace.core.populate.instance;
 public class EnumInstanceFactory implements InstanceFactory {
     public static final InstanceFactory INSTANCE = new EnumInstanceFactory();
 
-    private static boolean notSupportedType(final Class<?> rawType) {
-        return !rawType.isEnum();
-    }
-
     @Override
     public <T> T createInstance(Class<? extends T> rawType, final Object parent, final InstanceFactories instanceFactories) {
-        if (notSupportedType(rawType)) {
+        if (unSupportedType(rawType)) {
             return null;
         }
 
@@ -52,5 +48,9 @@ public class EnumInstanceFactory implements InstanceFactory {
     @Override
     public String toString() {
         return getClass().getSimpleName();
+    }
+
+    private static boolean unSupportedType(final Class<?> rawType) {
+        return !rawType.isEnum();
     }
 }

--- a/populace-core/src/main/java/org/datalorax/populace/core/populate/instance/InstanceFactories.java
+++ b/populace-core/src/main/java/org/datalorax/populace/core/populate/instance/InstanceFactories.java
@@ -98,16 +98,18 @@ public class InstanceFactories {
      *
      * @param type the specific type to find.
      * @return the instance factory if found, else Optional.empty()
+     * @see org.datalorax.populace.core.util.ImmutableTypeMap#getSpecific(java.lang.reflect.Type)
      */
     public Optional<InstanceFactory> getSpecific(final Type type) {
         return Optional.ofNullable(factories.getSpecific(type));
     }
 
     /**
-     * Get the instance factory registered against the super {@code type} provided, is present.
+     * Get the most specific super instance factory registered for the {@code type} provided, is present.
      *
      * @param type the super type to find.
      * @return the instance factory if found, else Optional.empty()
+     * @see org.datalorax.populace.core.util.ImmutableTypeMap#getSuper(Class)
      */
     public Optional<InstanceFactory> getSuper(final Class<?> type) {
         return Optional.ofNullable(factories.getSuper(type));
@@ -117,6 +119,7 @@ public class InstanceFactories {
      * Get the default instance factory for array types.
      *
      * @return the instance factory
+     * @see org.datalorax.populace.core.util.ImmutableTypeMap#getArrayDefault()
      */
     public InstanceFactory getArrayDefault() {
         return factories.getArrayDefault();
@@ -126,12 +129,11 @@ public class InstanceFactories {
      * Get the default instance factory for none-array types.
      *
      * @return the instance factory
+     * @see org.datalorax.populace.core.util.ImmutableTypeMap#getDefault()
      */
     public InstanceFactory getDefault() {
         return factories.getDefault();
     }
-
-    // Todo(ac): expose the same accessors across mutators & inspectors?
 
     @Override
     public boolean equals(final Object o) {

--- a/populace-core/src/main/java/org/datalorax/populace/core/populate/instance/LoggingInstanceFactory.java
+++ b/populace-core/src/main/java/org/datalorax/populace/core/populate/instance/LoggingInstanceFactory.java
@@ -24,6 +24,7 @@ import org.apache.commons.logging.LogFactory;
  *
  * @author Andrew Coates - 02/03/2015.
  */
+// Todo(ac): rename to LoggingNullObjectStrategy in v2.x
 public class LoggingInstanceFactory implements NullObjectStrategy {
     public static final LoggingInstanceFactory INSTANCE = new LoggingInstanceFactory();
     private static final Log LOG = LogFactory.getLog(LoggingInstanceFactory.class);

--- a/populace-core/src/main/java/org/datalorax/populace/core/populate/instance/ThrowingInstanceFactory.java
+++ b/populace-core/src/main/java/org/datalorax/populace/core/populate/instance/ThrowingInstanceFactory.java
@@ -22,6 +22,7 @@ package org.datalorax.populace.core.populate.instance;
  *
  * @author Andrew Coates - 02/03/2015.
  */
+// Todo(ac): rename to ThrowingNullObjectStrategy in v2.x
 public class ThrowingInstanceFactory implements NullObjectStrategy {
     public static final ThrowingInstanceFactory INSTANCE = new ThrowingInstanceFactory();
 

--- a/populace-core/src/main/java/org/datalorax/populace/core/populate/mutator/Mutators.java
+++ b/populace-core/src/main/java/org/datalorax/populace/core/populate/mutator/Mutators.java
@@ -22,6 +22,7 @@ import org.datalorax.populace.core.populate.mutator.commbination.ChainedMutator;
 import org.datalorax.populace.core.util.ImmutableTypeMap;
 
 import java.lang.reflect.Type;
+import java.util.Optional;
 
 /**
  * Helper functions for working with {@link org.datalorax.populace.core.populate.Mutator mutators}
@@ -71,8 +72,57 @@ public class Mutators {
         return ChainedMutator.chain(first, second, additional);
     }
 
-    public Mutator get(final Type key) {
-        return mutators.get(key);
+    /**
+     * Get the mutator most specific to the provided {@code type}.
+     *
+     * @param type the specific type to find
+     * @return the mutator
+     * @see org.datalorax.populace.core.util.ImmutableTypeMap#get(java.lang.reflect.Type) for details
+     */
+    public Mutator get(final Type type) {
+        return mutators.get(type);
+    }
+
+    /**
+     * Get the mutator registered against the specific {@code type} provided, is present.
+     *
+     * @param type the specific type to find.
+     * @return the mutator if found, else Optional.empty()
+     * @see org.datalorax.populace.core.util.ImmutableTypeMap#getSpecific(java.lang.reflect.Type)
+     */
+    public Optional<Mutator> getSpecific(final Type type) {
+        return Optional.ofNullable(mutators.getSpecific(type));
+    }
+
+    /**
+     * Get the most specific super mutator registered for the {@code type} provided, is present.
+     *
+     * @param type the super type to find.
+     * @return the mutator if found, else Optional.empty()
+     * @see org.datalorax.populace.core.util.ImmutableTypeMap#getSuper(Class)
+     */
+    public Optional<Mutator> getSuper(final Class<?> type) {
+        return Optional.ofNullable(mutators.getSuper(type));
+    }
+
+    /**
+     * Get the default mutator for array types.
+     *
+     * @return the mutator
+     * @see org.datalorax.populace.core.util.ImmutableTypeMap#getArrayDefault()
+     */
+    public Mutator getArrayDefault() {
+        return mutators.getArrayDefault();
+    }
+
+    /**
+     * Get the default mutator for none-array types.
+     *
+     * @return the mutator
+     * @see org.datalorax.populace.core.util.ImmutableTypeMap#getDefault()
+     */
+    public Mutator getDefault() {
+        return mutators.getDefault();
     }
 
     @Override

--- a/populace-core/src/main/java/org/datalorax/populace/core/util/ImmutableTypeMap.java
+++ b/populace-core/src/main/java/org/datalorax/populace/core/util/ImmutableTypeMap.java
@@ -81,11 +81,14 @@ public class ImmutableTypeMap<V> {
 
     /**
      * Returns the most specific value for the provided key. Matches are found in the following priority:
-     * specific, super, default, where default is either array or non-array depending on if the key is an array type.
+     *
+     * For <b>non-array key types</b>: specific, super, package, default
+     * For <b>array key types</b>: specific, array-default
      *
      * @param key to look up
      * @return the most specific value found, or null if no value found.
      */
+    // Todo(ac): If this can return null change to return optional in v2.x
     public V get(final Type key) {
         V value = getSpecific(key);
         if (value != null) {
@@ -113,7 +116,7 @@ public class ImmutableTypeMap<V> {
     }
 
     /**
-     * Return the value matching this specific key. Only a type registered with this specific key will be found.
+     * Returns the value matching this specific key. Only a type registered with this exact key will be found.
      *
      * @param key the key to lookup
      * @return the value matching this specific key, if found, else null.
@@ -126,7 +129,11 @@ public class ImmutableTypeMap<V> {
     }
 
     /**
-     * Return the best match for this super key. The value for the most specific super key will be returned.
+     * Returns the best match for this super key. The value for the most specific super key will be returned.
+     *
+     * For example, if {@code key} was {@code ArrayList.class} and values were registered for both {@code List} and
+     * {@code Collection}, then this method would return the value associated with the {@code List} entry, as this has
+     * a closer relationship
      *
      * @param key the key to lookup
      * @return the most value for the most specific super key, if found, else null.
@@ -150,6 +157,16 @@ public class ImmutableTypeMap<V> {
         return bestMatch == null ? null : bestMatch.getValue();
     }
 
+    /**
+     * Returns the best match for the {@code packageName} provided.
+     * <p>
+     * For example, if {@code packgeName} was {@code org.someone.p1.p2} and values were were registered for both
+     * {@code org.someone} and {@code org.someone.p1}, then this method would return the value associated with the
+     * {@code org.someone.p1} entry, as this is a closer match.
+     *
+     * @param packageName the package name to look up
+     * @return the most value of the most specific package key, if found, else null.
+     */
     // Todo(ac): Switch to Optional in v2.x
     public V getPackage(final String packageName) {
         Validate.notEmpty(packageName, "packageName empty");
@@ -171,16 +188,19 @@ public class ImmutableTypeMap<V> {
     }
 
     /**
+     * Returns the value that will be used for array types, if no specific type is registered.
      * @return the default value for array types if one is present, else null. If present, this will override the
      * {@link ImmutableTypeMap#getDefault() default value} for any array types.
      */
+    // Todo(ac): switch to Optional in v2.x
     public V getArrayDefault() {
         return arrayDefaultValue;
     }
 
     /**
-     * @return the default value for non-array types, if there is a specific array default installed, or all types.
-     * This will never return null.
+     * Returns the default value that will be used if no others are registered to handle a specific type.
+     *
+     * @return the default value.
      */
     public V getDefault() {
         return defaultValue;

--- a/populace-core/src/main/java/org/datalorax/populace/core/util/TypeResolver.java
+++ b/populace-core/src/main/java/org/datalorax/populace/core/util/TypeResolver.java
@@ -27,13 +27,17 @@ import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
 /**
+ * TypeResolver is capable of resolving {@link java.lang.reflect.TypeVariable TypeVariables} using the provided
+ * {@code typeTable} for the different flavours of {@link java.lang.reflect.Type}. The constituent type arguments and
+ * bounds are resolved in a recursive manner using the type information available in the type table.
+ *
  * @author Andrew Coates - 02/04/2015.
  */
 public class TypeResolver {
     private final TypeTable typeTable;
 
     /**
-     * Creates a resolver that will use the type available in the supplied {@code typeTable} to resolve types
+     * Creates a resolver that will use the information available in the supplied {@code typeTable} to resolve types
      *
      * @param typeTable the type table to use to resolve type variables
      */
@@ -44,17 +48,22 @@ public class TypeResolver {
 
     /**
      * Resolve the provided {@code type} using the type information available
-     * <p>
-     * if {@code type} is a {@link Class} with type parameters, then it will return a {@link ParameterizedType} where the
-     * type parameters have been as resolved as much as is possible.
-     * <p>
-     * if {@code type} is a {@link Class} without type parameters, then the class is returned unchanged.
-     * <p>
-     * if {@code type} is a {@link ParameterizedType}, then it will return the parameterized type with its type parameters
-     * resolved as much as is possible.
-     *
+     * <ul>
+     * <li>if {@code type} is a {@link java.lang.Class} with type parameters, then it will return a {@link ParameterizedType} where the
+     * type parameters have been as resolved as far as is possible.</li>
+     * <li>if {@code type} is a {@link java.lang.Class} without type parameters, then the class is returned unchanged.</li>
+     * <li>if {@code type} is a {@link java.lang.reflect.ParameterizedType}, then it will return the type with its type parameters
+     * resolved as much as is possible.</li>
+     * <li>if {@code type} is a {@link java.lang.reflect.TypeVariable}, then it will recursively resolve the type using the type table,
+     * returning the final state</li>
+     * <li>if {@code type} is a {@link java.lang.reflect.WildcardType}, then it will return the type with any
+     * bounds resolved as far as is possible</li>
+     * <li>if {@code type} is a {@link java.lang.reflect.GenericArrayType}, then it will return the type with its component
+     * type resolved as far as is possible</li>
+     * </ul>
      * @param type the type to resolve
      * @return the resolved type.
+     * @throws java.lang.UnsupportedOperationException on unsupported implementation of {@link java.lang.reflect.Type}
      */
     public Type resolve(final Type type) {
         return resolve(type, null);

--- a/populace-core/src/main/java/org/datalorax/populace/core/util/TypeUtils.java
+++ b/populace-core/src/main/java/org/datalorax/populace/core/util/TypeUtils.java
@@ -124,17 +124,7 @@ public final class TypeUtils {
      */
     @Deprecated     // Todo(ac): remove in v2.x
     public static <T> Type getTypeArgument(final Type type, final Class<T> toClass, final TypeVariable<Class<T>> typeVariable) {
-        if (toClass.equals(type)) {
-            return typeVariable;
-        }
-
-        final Map<TypeVariable<?>, Type> typeArguments = org.apache.commons.lang3.reflect.TypeUtils.getTypeArguments(type, toClass);
-        if (typeArguments == null) {
-            throw new IllegalArgumentException(type + " is not assignable to " + toClass);
-        }
-
-        final Type typeArg = typeArguments.get(typeVariable);
-        return typeArg == null ? Object.class : typeArg;
+        return getTypeArgument(type, typeVariable);
     }
 
     /**
@@ -297,7 +287,7 @@ public final class TypeUtils {
             return ensureConsistentGenericArrayType((GenericArrayType) type);
         }
 
-        throw new UnsupportedOperationException("Unsupported type: " + type.getClass());
+        throw new IllegalArgumentException("Unexpected type: " + type.getClass());
     }
 
     private static Type ensureConsistentParameterisedType(final ParameterizedType type) {

--- a/populace-core/src/main/java/org/datalorax/populace/core/walk/field/FieldInfo.java
+++ b/populace-core/src/main/java/org/datalorax/populace/core/walk/field/FieldInfo.java
@@ -23,6 +23,8 @@ import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
 
 /**
+ * Represents the information and operations available for a particular field on a particular instance.
+ *
  * @author Andrew Coates - 04/03/2015.
  */
 public class FieldInfo {
@@ -31,6 +33,14 @@ public class FieldInfo {
     private final TypeResolver typeResolver;
     private final PathProvider pathProvider;
 
+    /**
+     * Construct a new FieldInfo object
+     *
+     * @param field          the raw field this instance should augment
+     * @param owningInstance the instance from which to get / set the current value of this field
+     * @param typeResolver   the resolver to use to resolve generic types
+     * @param pathProvider   the provider of the path to this instance.
+     */
     public FieldInfo(final RawField field, final Object owningInstance, final TypeResolver typeResolver, final PathProvider pathProvider) {
         Validate.notNull(field, "field null");
         Validate.notNull(owningInstance, "owningInstance null");
@@ -67,7 +77,14 @@ public class FieldInfo {
     }
 
     /**
-     * Todo(ac): Document the steps it uses to determine generic type info in the readme.
+     * Returns the generic type of the field, resolved using all available type information e.g. type variables are resolved
+     * where type information higher up the stack is available.
+     *
+     * <ul>
+     * <li>For <b>primitive types</b> this method returns the type of the field.</li>
+     * <li>For <b>non-primitive types with a null value</b> this method returns the resolved generic type of the field</li>
+     * <li>For <b>non-primitive types with a non-null value</b> this method returns the resolved generic type of the value</li>
+     * </ul>
      * @return the generic type of the field
      * @see RawField#getGenericType()
      */

--- a/populace-core/src/main/java/org/datalorax/populace/core/walk/inspector/Inspectors.java
+++ b/populace-core/src/main/java/org/datalorax/populace/core/walk/inspector/Inspectors.java
@@ -22,6 +22,7 @@ import org.datalorax.populace.core.walk.inspector.annotation.AnnotationInspector
 import org.datalorax.populace.core.walk.inspector.annotation.ChainedAnnotationInspector;
 
 import java.lang.reflect.Type;
+import java.util.Optional;
 
 /**
  * Helper functions for working with {@link Inspector inspectors}
@@ -79,13 +80,67 @@ public class Inspectors {
     }
 
     /**
-     * Get the inspector with the collection that handles the supplied {@code type}.
+     * Get the inspector most specific to the provided {@code type}.
      *
-     * @param type the tye an inspector is required for
-     * @return the inspector that handles the supplied {@code type}.
+     * @param type the specific type to find
+     * @return the inspector
+     * @see org.datalorax.populace.core.util.ImmutableTypeMap#get(java.lang.reflect.Type) for details
      */
     public Inspector get(final Type type) {
         return inspectors.get(type);
+    }
+
+    /**
+     * Get the inspector registered against the specific {@code type} provided, is present.
+     *
+     * @param type the specific type to find.
+     * @return the inspector if found, else Optional.empty()
+     * @see org.datalorax.populace.core.util.ImmutableTypeMap#getSpecific(java.lang.reflect.Type)
+     */
+    public Optional<Inspector> getSpecific(final Type type) {
+        return Optional.ofNullable(inspectors.getSpecific(type));
+    }
+
+    /**
+     * Get the specific super inspector registered for the {@code type} provided, is present.
+     *
+     * @param type the super type to find.
+     * @return the inspector if found, else Optional.empty()
+     * @see org.datalorax.populace.core.util.ImmutableTypeMap#getSuper(Class)
+     */
+    public Optional<Inspector> getSuper(final Class<?> type) {
+        return Optional.ofNullable(inspectors.getSuper(type));
+    }
+
+    /**
+     * Get the most specific inspector registered for the {@code packageName} provided, is present.
+     *
+     * @param packageName the name of the package.
+     * @return the inspector if found, else Optional.empty()
+     * @see org.datalorax.populace.core.util.ImmutableTypeMap#getPackage(String)
+     */
+    public Optional<Inspector> getPackage(final String packageName) {
+        return Optional.ofNullable(inspectors.getPackage(packageName));
+    }
+
+    /**
+     * Get the default inspector for array types.
+     *
+     * @return the inspector
+     * @see org.datalorax.populace.core.util.ImmutableTypeMap#getArrayDefault()
+     */
+    public Inspector getArrayDefault() {
+        return inspectors.getArrayDefault();
+    }
+
+    /**
+     * Get the default inspector for none-array types.
+     *
+     * @return the inspector
+     * @see org.datalorax.populace.core.util.ImmutableTypeMap#getDefault()
+     */
+    public Inspector getDefault() {
+        return inspectors.getDefault();
     }
 
     /**
@@ -103,12 +158,14 @@ public class Inspectors {
         if (o == null || getClass() != o.getClass()) return false;
 
         final Inspectors that = (Inspectors) o;
-        return inspectors.equals(that.inspectors);
+        return annotationInspector.equals(that.annotationInspector) && inspectors.equals(that.inspectors);
     }
 
     @Override
     public int hashCode() {
-        return inspectors.hashCode();
+        int result = inspectors.hashCode();
+        result = 31 * result + annotationInspector.hashCode();
+        return result;
     }
 
     @Override

--- a/populace-core/src/test/java/org/datalorax/populace/core/populate/instance/ArrayInstanceFactoryTest.java
+++ b/populace-core/src/test/java/org/datalorax/populace/core/populate/instance/ArrayInstanceFactoryTest.java
@@ -16,6 +16,7 @@
 
 package org.datalorax.populace.core.populate.instance;
 
+import com.google.common.testing.EqualsTester;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
@@ -65,5 +66,16 @@ public class ArrayInstanceFactoryTest {
         assertThat(instance, is(notNullValue()));
         assertThat(instance.length, is(1));
         assertThat(instance[0], is(nullValue()));
+    }
+
+    @Test
+    public void shouldTestEqualsAndHashCode() throws Exception {
+        new EqualsTester()
+            .addEqualityGroup(
+                ArrayInstanceFactory.INSTANCE,
+                new ArrayInstanceFactory())
+            .addEqualityGroup(
+                mock(InstanceFactory.class))
+            .testEquals();
     }
 }

--- a/populace-core/src/test/java/org/datalorax/populace/core/populate/instance/BigDecimalInstanceFactoryTest.java
+++ b/populace-core/src/test/java/org/datalorax/populace/core/populate/instance/BigDecimalInstanceFactoryTest.java
@@ -16,6 +16,8 @@
 
 package org.datalorax.populace.core.populate.instance;
 
+import com.google.common.testing.EqualsTester;
+import com.google.common.testing.NullPointerTester;
 import org.testng.annotations.Test;
 
 import java.math.BigDecimal;
@@ -26,11 +28,6 @@ import static org.hamcrest.Matchers.sameInstance;
 import static org.mockito.Mockito.mock;
 
 public class BigDecimalInstanceFactoryTest {
-    @Test(expectedExceptions = NullPointerException.class)
-    public void shouldThrowOnNullConstructorArg() throws Exception {
-        new BigDecimalInstanceFactory(null);
-    }
-
     @Test
     public void shouldReturnDefaultProvided() throws Exception {
         // Given:
@@ -42,5 +39,25 @@ public class BigDecimalInstanceFactoryTest {
 
         // Then:
         assertThat(instance, is(sameInstance(defaultValue)));
+    }
+
+    @Test
+    public void shouldTestEqualsAndHashCode() throws Exception {
+        final BigDecimal defaultValue = new BigDecimal(1.234);
+
+        new EqualsTester()
+            .addEqualityGroup(
+                new BigDecimalInstanceFactory(defaultValue),
+                new BigDecimalInstanceFactory(defaultValue),
+                new BigDecimalInstanceFactory(new BigDecimal(1.234)))
+            .addEqualityGroup(
+                new BigDecimalInstanceFactory(new BigDecimal(1.233)))
+            .testEquals();
+    }
+
+    @Test
+    public void shouldThrowNPEsOnConstructorParams() throws Exception {
+        new NullPointerTester()
+            .testAllPublicConstructors(BigDecimalInstanceFactory.class);
     }
 }

--- a/populace-core/src/test/java/org/datalorax/populace/core/populate/instance/DefaultConstructorInstanceFactoryTest.java
+++ b/populace-core/src/test/java/org/datalorax/populace/core/populate/instance/DefaultConstructorInstanceFactoryTest.java
@@ -16,6 +16,7 @@
 
 package org.datalorax.populace.core.populate.instance;
 
+import com.google.common.testing.EqualsTester;
 import org.datalorax.populace.core.populate.PopulatorException;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
@@ -23,6 +24,7 @@ import org.testng.annotations.Test;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.mockito.Mockito.mock;
 
 public class DefaultConstructorInstanceFactoryTest {
     private InstanceFactory factory;
@@ -78,6 +80,12 @@ public class DefaultConstructorInstanceFactoryTest {
     }
 
     @Test(expectedExceptions = PopulatorException.class)
+    public void shouldThrowIfNoInnerTypeWithNoDefaultConstructor() throws Exception {
+        // When:
+        factory.createInstance(InnerTypeWithNoDefaultConstructor.class, this, null);
+    }
+
+    @Test(expectedExceptions = PopulatorException.class)
     public void shouldThrowIfInterface() throws Exception {
         // When:
         factory.createInstance(InterfaceType.class, null, null);
@@ -87,6 +95,17 @@ public class DefaultConstructorInstanceFactoryTest {
     public void shouldThrowIfAbstract() throws Exception {
         // When:
         factory.createInstance(AbstractType.class, null, null);
+    }
+
+    @Test
+    public void shouldTestEqualsAndHashCode() throws Exception {
+        new EqualsTester()
+            .addEqualityGroup(
+                DefaultConstructorInstanceFactory.INSTANCE,
+                new DefaultConstructorInstanceFactory())
+            .addEqualityGroup(
+                mock(InstanceFactory.class))
+            .testEquals();
     }
 
     public interface InterfaceType {
@@ -115,5 +134,11 @@ public class DefaultConstructorInstanceFactoryTest {
     }
 
     public static abstract class AbstractType {
+    }
+
+    public final class InnerTypeWithNoDefaultConstructor {
+        @SuppressWarnings("UnusedParameters")
+        public InnerTypeWithNoDefaultConstructor(String s) {
+        }
     }
 }

--- a/populace-core/src/test/java/org/datalorax/populace/core/populate/instance/DefaultTypeInstanceFactoryTest.java
+++ b/populace-core/src/test/java/org/datalorax/populace/core/populate/instance/DefaultTypeInstanceFactoryTest.java
@@ -16,13 +16,12 @@
 
 package org.datalorax.populace.core.populate.instance;
 
+import com.google.common.testing.EqualsTester;
+import com.google.common.testing.NullPointerTester;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
-import java.util.AbstractSequentialList;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Vector;
+import java.util.*;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
@@ -44,21 +43,6 @@ public class DefaultTypeInstanceFactoryTest {
         instanceFactories = mock(InstanceFactories.class);
 
         factory = new DefaultTypeInstanceFactory(baseType, defaultType, concreteFactory);
-    }
-
-    @Test(expectedExceptions = NullPointerException.class)
-    public void shouldThrowIfNullBaseType() throws Exception {
-        new DefaultTypeInstanceFactory(null, defaultType, concreteFactory);
-    }
-
-    @Test(expectedExceptions = NullPointerException.class)
-    public void shouldThrowIfNullDefaultType() throws Exception {
-        new DefaultTypeInstanceFactory(baseType, null, concreteFactory);
-    }
-
-    @Test(expectedExceptions = NullPointerException.class)
-    public void shouldThrowIfNullConcreteFactory() throws Exception {
-        new DefaultTypeInstanceFactory(baseType, defaultType, null);
     }
 
     @Test
@@ -125,5 +109,32 @@ public class DefaultTypeInstanceFactoryTest {
 
         // Then:
         assertThat(instance, is(expected));
+    }
+
+    @Test
+    public void shouldTestEqualsAndHashCode() throws Exception {
+        final Class<Map> baseType = Map.class;
+        final Class<HashMap> defaultType = HashMap.class;
+        final InstanceFactory concreteFactory = mock(InstanceFactory.class, "1");
+        final InstanceFactory concreteFactory2 = mock(InstanceFactory.class, "2");
+
+        new EqualsTester()
+            .addEqualityGroup(
+                new DefaultTypeInstanceFactory(baseType, defaultType, concreteFactory),
+                new DefaultTypeInstanceFactory(baseType, defaultType, concreteFactory))
+            .addEqualityGroup(
+                new DefaultTypeInstanceFactory(HashMap.class, defaultType, concreteFactory))
+            .addEqualityGroup(
+                new DefaultTypeInstanceFactory(baseType, TreeMap.class, concreteFactory))
+            .addEqualityGroup(
+                new DefaultTypeInstanceFactory(baseType, defaultType, concreteFactory2))
+            .testEquals();
+    }
+
+    @Test
+    public void shouldThrowNPEsOnConstructorParams() throws Exception {
+        new NullPointerTester()
+            .setDefault(InstanceFactory.class, mock(InstanceFactory.class))
+            .testAllPublicConstructors(DefaultTypeInstanceFactory.class);
     }
 }

--- a/populace-core/src/test/java/org/datalorax/populace/core/populate/instance/EnumInstanceFactoryTest.java
+++ b/populace-core/src/test/java/org/datalorax/populace/core/populate/instance/EnumInstanceFactoryTest.java
@@ -16,12 +16,14 @@
 
 package org.datalorax.populace.core.populate.instance;
 
+import com.google.common.testing.EqualsTester;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
+import static org.mockito.Mockito.mock;
 
 public class EnumInstanceFactoryTest {
     private InstanceFactory factory;
@@ -56,6 +58,17 @@ public class EnumInstanceFactoryTest {
 
         // Then:
         assertThat(instance, is(nullValue()));
+    }
+
+    @Test
+    public void shouldTestEqualsAndHashCode() throws Exception {
+        new EqualsTester()
+            .addEqualityGroup(
+                EnumInstanceFactory.INSTANCE,
+                new EnumInstanceFactory())
+            .addEqualityGroup(
+                mock(InstanceFactory.class))
+            .testEquals();
     }
 
     private static enum NonEmptyEnum {

--- a/populace-core/src/test/java/org/datalorax/populace/core/populate/instance/InstanceFactoriesTest.java
+++ b/populace-core/src/test/java/org/datalorax/populace/core/populate/instance/InstanceFactoriesTest.java
@@ -16,6 +16,8 @@
 
 package org.datalorax.populace.core.populate.instance;
 
+import com.google.common.testing.EqualsTester;
+import org.datalorax.populace.core.util.ImmutableTypeMap;
 import org.datalorax.populace.core.util.TypeUtils;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
@@ -30,7 +32,6 @@ import static org.hamcrest.Matchers.*;
 import static org.mockito.Mockito.*;
 
 public class InstanceFactoriesTest {
-
     private InstanceFactories.Builder builder;
     private InstanceFactories factories;
 
@@ -263,5 +264,35 @@ public class InstanceFactoriesTest {
 
         // Then:
         assertThat(string, containsString("Fork Handles"));
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void shouldTestEqualsAndHashCode() throws Exception {
+        final NullObjectStrategy nullObjectStrategy = mock(NullObjectStrategy.class, "1");
+        final ImmutableTypeMap<InstanceFactory> rawFactories = mock(ImmutableTypeMap.class, "1");
+
+        new EqualsTester()
+            .addEqualityGroup(
+                new InstanceFactories(nullObjectStrategy, rawFactories),
+                new InstanceFactories(nullObjectStrategy, rawFactories))
+            .addEqualityGroup(
+                new InstanceFactories(mock(NullObjectStrategy.class, "2"), rawFactories))
+            .addEqualityGroup(
+                new InstanceFactories(nullObjectStrategy, mock(ImmutableTypeMap.class, "2")))
+            .testEquals();
+    }
+
+    @Test
+    public void shouldTestEqualsAndHashCodeOfNullObjectInstanceFactory() throws Exception {
+        final NullObjectStrategy nullObjectStrategy = mock(NullObjectStrategy.class, "1");
+
+        new EqualsTester()
+            .addEqualityGroup(
+                new InstanceFactories.NullObjectInstanceFactory(nullObjectStrategy),
+                new InstanceFactories.NullObjectInstanceFactory(nullObjectStrategy))
+            .addEqualityGroup(
+                new InstanceFactories.NullObjectInstanceFactory(mock(NullObjectStrategy.class, "2")))
+            .testEquals();
     }
 }

--- a/populace-core/src/test/java/org/datalorax/populace/core/populate/instance/LoggingInstanceFactoryTest.java
+++ b/populace-core/src/test/java/org/datalorax/populace/core/populate/instance/LoggingInstanceFactoryTest.java
@@ -14,39 +14,27 @@
  * limitations under the License.
  */
 
-package org.datalorax.populace.core.populate.mutator.ensure;
+package org.datalorax.populace.core.populate.instance;
 
 import com.google.common.testing.EqualsTester;
-import org.datalorax.populace.core.populate.Mutator;
-import org.datalorax.populace.core.walk.inspector.Inspector;
 import org.testng.annotations.Test;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.nullValue;
 import static org.mockito.Mockito.mock;
 
-public class EnsureNullMutatorTest {
+public class LoggingInstanceFactoryTest {
     @Test
-    public void shouldMostCertainlyReturnNull() throws Exception {
-        // Given:
-        final Mutator mutator = EnsureNullMutator.INSTANCE;
-
-        // When:
-        final Object mutated = mutator.mutate(String.class, "hello", null, null);
-
-        // Then:
-        assertThat(mutated, is(nullValue()));
+    public void shouldNotBlowUp() throws Exception {
+        new LoggingInstanceFactory().onNullObject(null);
     }
 
     @Test
     public void shouldTestEqualsAndHashCode() throws Exception {
         new EqualsTester()
             .addEqualityGroup(
-                EnsureNullMutator.INSTANCE,
-                new EnsureNullMutator())
+                LoggingInstanceFactory.INSTANCE,
+                new LoggingInstanceFactory())
             .addEqualityGroup(
-                mock(Inspector.class))
+                mock(InstanceFactory.class))
             .testEquals();
     }
 }

--- a/populace-core/src/test/java/org/datalorax/populace/core/populate/instance/PrimitiveInstanceFactoryTest.java
+++ b/populace-core/src/test/java/org/datalorax/populace/core/populate/instance/PrimitiveInstanceFactoryTest.java
@@ -16,6 +16,7 @@
 
 package org.datalorax.populace.core.populate.instance;
 
+import com.google.common.testing.EqualsTester;
 import org.datalorax.populace.core.util.TypeUtils;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -24,17 +25,9 @@ import java.util.List;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
+import static org.mockito.Mockito.mock;
 
 public class PrimitiveInstanceFactoryTest {
-    private static Object[][] asObjectArray(final List<Class<?>> types) {
-        final Object[][] data = new Object[types.size()][];
-        int i = 0;
-        for (Class<?> type : types) {
-            data[i++] = new Object[]{type};
-        }
-        return data;
-    }
-
     @Test(dataProvider = "primitive")
     public void shouldSupportPrimitiveType(Class<?> type) throws Exception {
         // Given:
@@ -62,6 +55,17 @@ public class PrimitiveInstanceFactoryTest {
         assertThat(PrimitiveInstanceFactory.INSTANCE.createInstance(String.class, null, null), is(nullValue()));
     }
 
+    @Test
+    public void shouldTestEqualsAndHashCode() throws Exception {
+        new EqualsTester()
+            .addEqualityGroup(
+                PrimitiveInstanceFactory.INSTANCE,
+                new PrimitiveInstanceFactory())
+            .addEqualityGroup(
+                mock(InstanceFactory.class))
+            .testEquals();
+    }
+
     @DataProvider(name = "primitive")
     public Object[][] getPrimitives() {
         return asObjectArray(TypeUtils.getPrimitiveTypes());
@@ -70,5 +74,14 @@ public class PrimitiveInstanceFactoryTest {
     @DataProvider(name = "boxed")
     public Object[][] getBoxedPrimitives() {
         return asObjectArray(TypeUtils.getBoxedPrimitiveTypes());
+    }
+
+    private static Object[][] asObjectArray(final List<Class<?>> types) {
+        final Object[][] data = new Object[types.size()][];
+        int i = 0;
+        for (Class<?> type : types) {
+            data[i++] = new Object[]{type};
+        }
+        return data;
     }
 }

--- a/populace-core/src/test/java/org/datalorax/populace/core/populate/instance/ThrowingInstanceFactoryTest.java
+++ b/populace-core/src/test/java/org/datalorax/populace/core/populate/instance/ThrowingInstanceFactoryTest.java
@@ -14,39 +14,28 @@
  * limitations under the License.
  */
 
-package org.datalorax.populace.core.populate.mutator.ensure;
+package org.datalorax.populace.core.populate.instance;
 
 import com.google.common.testing.EqualsTester;
-import org.datalorax.populace.core.populate.Mutator;
-import org.datalorax.populace.core.walk.inspector.Inspector;
 import org.testng.annotations.Test;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.nullValue;
 import static org.mockito.Mockito.mock;
 
-public class EnsureNullMutatorTest {
-    @Test
-    public void shouldMostCertainlyReturnNull() throws Exception {
+public class ThrowingInstanceFactoryTest {
+    @Test(expectedExceptions = UnsupportedOperationException.class)
+    public void shouldThrowOnNullObject() throws Exception {
         // Given:
-        final Mutator mutator = EnsureNullMutator.INSTANCE;
+        final Object parent = new Object();
 
         // When:
-        final Object mutated = mutator.mutate(String.class, "hello", null, null);
-
-        // Then:
-        assertThat(mutated, is(nullValue()));
+        new ThrowingInstanceFactory().onNullObject(parent);
     }
 
     @Test
     public void shouldTestEqualsAndHashCode() throws Exception {
         new EqualsTester()
-            .addEqualityGroup(
-                EnsureNullMutator.INSTANCE,
-                new EnsureNullMutator())
-            .addEqualityGroup(
-                mock(Inspector.class))
+            .addEqualityGroup(new ThrowingInstanceFactory(), new ThrowingInstanceFactory())
+            .addEqualityGroup(mock(NullObjectStrategy.class))
             .testEquals();
     }
 }

--- a/populace-core/src/test/java/org/datalorax/populace/core/populate/mutator/DateMutatorTest.java
+++ b/populace-core/src/test/java/org/datalorax/populace/core/populate/mutator/DateMutatorTest.java
@@ -16,8 +16,10 @@
 
 package org.datalorax.populace.core.populate.mutator;
 
+import com.google.common.testing.EqualsTester;
 import org.datalorax.populace.core.populate.Mutator;
 import org.datalorax.populace.core.populate.PopulatorContext;
+import org.datalorax.populace.core.populate.instance.InstanceFactory;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
@@ -64,5 +66,16 @@ public class DateMutatorTest {
 
         // Then:
         assertThat(populated, is(not(nullValue())));
+    }
+
+    @Test
+    public void shouldTestEqualsAndHashCode() throws Exception {
+        new EqualsTester()
+            .addEqualityGroup(
+                DateMutator.INSTANCE,
+                new DateMutator())
+            .addEqualityGroup(
+                mock(InstanceFactory.class))
+            .testEquals();
     }
 }

--- a/populace-core/src/test/java/org/datalorax/populace/core/populate/mutator/NoOpMutatorTest.java
+++ b/populace-core/src/test/java/org/datalorax/populace/core/populate/mutator/NoOpMutatorTest.java
@@ -16,12 +16,15 @@
 
 package org.datalorax.populace.core.populate.mutator;
 
+import com.google.common.testing.EqualsTester;
 import org.datalorax.populace.core.populate.Mutator;
+import org.datalorax.populace.core.populate.instance.InstanceFactory;
 import org.testng.annotations.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.sameInstance;
+import static org.mockito.Mockito.mock;
 
 public class NoOpMutatorTest {
     @Test
@@ -35,5 +38,16 @@ public class NoOpMutatorTest {
 
         // Then:
         assertThat(mutated, is(sameInstance(original)));
+    }
+
+    @Test
+    public void shouldTestEqualsAndHashCode() throws Exception {
+        new EqualsTester()
+            .addEqualityGroup(
+                NoOpMutator.INSTANCE,
+                new NoOpMutator())
+            .addEqualityGroup(
+                mock(InstanceFactory.class))
+            .testEquals();
     }
 }

--- a/populace-core/src/test/java/org/datalorax/populace/core/populate/mutator/ensure/EnsureArrayElementsNotNullMutatorTest.java
+++ b/populace-core/src/test/java/org/datalorax/populace/core/populate/mutator/ensure/EnsureArrayElementsNotNullMutatorTest.java
@@ -16,8 +16,10 @@
 
 package org.datalorax.populace.core.populate.mutator.ensure;
 
+import com.google.common.testing.EqualsTester;
 import org.datalorax.populace.core.populate.PopulatorContext;
 import org.datalorax.populace.core.util.TypeUtils;
+import org.datalorax.populace.core.walk.inspector.Inspector;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
@@ -121,6 +123,17 @@ public class EnsureArrayElementsNotNullMutatorTest {
 
         // Then:
         verify(config).createInstance(any(Type.class), eq(null));
+    }
+
+    @Test
+    public void shouldTestEqualsAndHashCode() throws Exception {
+        new EqualsTester()
+            .addEqualityGroup(
+                EnsureArrayElementsNotNullMutator.INSTANCE,
+                new EnsureArrayElementsNotNullMutator())
+            .addEqualityGroup(
+                mock(Inspector.class))
+            .testEquals();
     }
 
     private static Type arrayType(final Class<?> componentType) {

--- a/populace-core/src/test/java/org/datalorax/populace/core/populate/mutator/ensure/EnsureCollectionNotEmptyMutatorTest.java
+++ b/populace-core/src/test/java/org/datalorax/populace/core/populate/mutator/ensure/EnsureCollectionNotEmptyMutatorTest.java
@@ -16,9 +16,11 @@
 
 package org.datalorax.populace.core.populate.mutator.ensure;
 
+import com.google.common.testing.EqualsTester;
 import org.datalorax.populace.core.populate.Mutator;
 import org.datalorax.populace.core.populate.PopulatorContext;
 import org.datalorax.populace.core.util.TypeUtils;
+import org.datalorax.populace.core.walk.inspector.Inspector;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
@@ -114,6 +116,17 @@ public class EnsureCollectionNotEmptyMutatorTest {
 
         // Then:
         assertThat(mutated, is(expected));
+    }
+
+    @Test
+    public void shouldTestEqualsAndHashCode() throws Exception {
+        new EqualsTester()
+            .addEqualityGroup(
+                EnsureCollectionNotEmptyMutator.INSTANCE,
+                new EnsureCollectionNotEmptyMutator())
+            .addEqualityGroup(
+                mock(Inspector.class))
+            .testEquals();
     }
 
     private void givenMutatorRegistered(final Type type, final Mutator mutator) {

--- a/populace-core/src/test/java/org/datalorax/populace/core/populate/mutator/ensure/EnsureListElementsNotNullMutatorTest.java
+++ b/populace-core/src/test/java/org/datalorax/populace/core/populate/mutator/ensure/EnsureListElementsNotNullMutatorTest.java
@@ -16,8 +16,10 @@
 
 package org.datalorax.populace.core.populate.mutator.ensure;
 
+import com.google.common.testing.EqualsTester;
 import org.datalorax.populace.core.populate.PopulatorContext;
 import org.datalorax.populace.core.util.TypeUtils;
+import org.datalorax.populace.core.walk.inspector.Inspector;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
@@ -182,6 +184,17 @@ public class EnsureListElementsNotNullMutatorTest {
 
         // Then:
         verify(config).createInstance(eq(Number.class), anyObject());
+    }
+
+    @Test
+    public void shouldTestEqualsAndHashCode() throws Exception {
+        new EqualsTester()
+            .addEqualityGroup(
+                EnsureListElementsNotNullMutator.INSTANCE,
+                new EnsureListElementsNotNullMutator())
+            .addEqualityGroup(
+                mock(Inspector.class))
+            .testEquals();
     }
 }
 

--- a/populace-core/src/test/java/org/datalorax/populace/core/populate/mutator/ensure/EnsureMapNotEmptyMutatorTest.java
+++ b/populace-core/src/test/java/org/datalorax/populace/core/populate/mutator/ensure/EnsureMapNotEmptyMutatorTest.java
@@ -16,9 +16,11 @@
 
 package org.datalorax.populace.core.populate.mutator.ensure;
 
+import com.google.common.testing.EqualsTester;
 import org.datalorax.populace.core.populate.Mutator;
 import org.datalorax.populace.core.populate.PopulatorContext;
 import org.datalorax.populace.core.util.TypeUtils;
+import org.datalorax.populace.core.walk.inspector.Inspector;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
@@ -116,6 +118,17 @@ public class EnsureMapNotEmptyMutatorTest {
 
         // Then:
         assertThat(mutated, is(expected));
+    }
+
+    @Test
+    public void shouldTestEqualsAndHashCode() throws Exception {
+        new EqualsTester()
+            .addEqualityGroup(
+                EnsureMapNotEmptyMutator.INSTANCE,
+                new EnsureMapNotEmptyMutator())
+            .addEqualityGroup(
+                mock(Inspector.class))
+            .testEquals();
     }
 
     private void givenMutatorRegistered(final Type type, final Mutator mutator) {

--- a/populace-core/src/test/java/org/datalorax/populace/core/populate/mutator/ensure/EnsureMapValuesNotNullMutatorTest.java
+++ b/populace-core/src/test/java/org/datalorax/populace/core/populate/mutator/ensure/EnsureMapValuesNotNullMutatorTest.java
@@ -16,8 +16,10 @@
 
 package org.datalorax.populace.core.populate.mutator.ensure;
 
+import com.google.common.testing.EqualsTester;
 import org.datalorax.populace.core.populate.PopulatorContext;
 import org.datalorax.populace.core.util.TypeUtils;
+import org.datalorax.populace.core.walk.inspector.Inspector;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
@@ -163,5 +165,16 @@ public class EnsureMapValuesNotNullMutatorTest {
 
         // Then:
         verify(config).createInstance(eq(Number.class), anyObject());
+    }
+
+    @Test
+    public void shouldTestEqualsAndHashCode() throws Exception {
+        new EqualsTester()
+            .addEqualityGroup(
+                EnsureMapValuesNotNullMutator.INSTANCE,
+                new EnsureMapValuesNotNullMutator())
+            .addEqualityGroup(
+                mock(Inspector.class))
+            .testEquals();
     }
 }

--- a/populace-core/src/test/java/org/datalorax/populace/core/util/ImmutableTypeMapTest.java
+++ b/populace-core/src/test/java/org/datalorax/populace/core/util/ImmutableTypeMapTest.java
@@ -17,6 +17,8 @@
 package org.datalorax.populace.core.util;
 
 
+import com.google.common.testing.EqualsTester;
+import com.google.common.testing.NullPointerTester;
 import org.testng.annotations.Test;
 
 import java.lang.reflect.GenericArrayType;
@@ -403,7 +405,38 @@ public class ImmutableTypeMapTest {
         assertThat(value, is("specific"));
     }
 
+    @Test
+    public void shouldTestEqualsAndHashCode() throws Exception {
+        final Map<Type, String> specificVs = Collections.singletonMap(Integer.class, "specific");
+        final Map<Class<?>, String> superVs = Collections.singletonMap(List.class, "super");
+        final Map<String, String> packageVs = Collections.singletonMap("some.package", "package");
+        final String arrayDefaultV = "array-default";
+        final String defaultV = "default";
+
+        new EqualsTester()
+            .addEqualityGroup(
+                new ImmutableTypeMap<>(specificVs, superVs, packageVs, arrayDefaultV, defaultV),
+                new ImmutableTypeMap<>(specificVs, superVs, packageVs, arrayDefaultV, defaultV))
+            .addEqualityGroup(
+                new ImmutableTypeMap<>(Collections.singletonMap(Map.class, "other"), superVs, packageVs, arrayDefaultV, defaultV))
+            .addEqualityGroup(
+                new ImmutableTypeMap<>(specificVs, Collections.singletonMap(Map.class, "other"), packageVs, arrayDefaultV, defaultV))
+            .addEqualityGroup(
+                new ImmutableTypeMap<>(specificVs, superVs, Collections.singletonMap("some.package", "other"), arrayDefaultV, defaultV))
+            .addEqualityGroup(
+                new ImmutableTypeMap<>(specificVs, superVs, packageVs, "other", defaultV))
+            .addEqualityGroup(
+                new ImmutableTypeMap<>(specificVs, superVs, packageVs, arrayDefaultV, "other"))
+            .testEquals();
+    }
+
+    @Test
+    public void shouldThrowNPEsOnConstructorParams() throws Exception {
+        new NullPointerTester().testAllPublicConstructors(ImmutableTypeMap.class);
+    }
+
     private static class ClassComparator implements Comparator<Class<?>> {
+
         @Override
         public int compare(final Class<?> c1, final Class<?> c2) {
             return c1.getCanonicalName().compareTo(c2.getCanonicalName());

--- a/populace-core/src/test/java/org/datalorax/populace/core/util/TypeUtilsTest.java
+++ b/populace-core/src/test/java/org/datalorax/populace/core/util/TypeUtilsTest.java
@@ -21,6 +21,7 @@ import org.testng.annotations.Test;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.lang.reflect.TypeVariable;
+import java.lang.reflect.WildcardType;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -113,5 +114,40 @@ public class TypeUtilsTest {
         assertThat(TypeUtils.getBoxedTypeForPrimitive(long.class), is(equalTo(Long.class)));
         assertThat(TypeUtils.getBoxedTypeForPrimitive(float.class), is(equalTo(Float.class)));
         assertThat(TypeUtils.getBoxedTypeForPrimitive(double.class), is(equalTo(Double.class)));
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void shouldThrowFromEnsureConsistentTypeForUnsupportedType() throws Exception {
+        TypeUtils.ensureConsistentType(mock(Type.class));
+    }
+
+    @Test
+    public void shouldCreateWildcardTypeWithNoLowerBounds() throws Exception {
+        // When:
+        final WildcardType wildcardType = TypeUtils.wildcardTypeWithUpperBounds(String.class);
+
+        // Then:
+        assertThat(wildcardType.getLowerBounds().length, is(0));
+    }
+
+    @Test
+    public void shouldCreateWildcardTypeWithSuppliedUpperBounds() throws Exception {
+        // When:
+        final WildcardType wildcardType = TypeUtils.wildcardTypeWithUpperBounds(String.class, Integer.class);
+
+        // Then:
+        assertThat(wildcardType.getUpperBounds().length, is(2));
+        assertThat(wildcardType.getUpperBounds()[0], is(equalTo(String.class)));
+        assertThat(wildcardType.getUpperBounds()[1], is(equalTo(Integer.class)));
+    }
+
+    @Test
+    public void shouldDefaultToWildcardTypeWithObjectUpperBounds() throws Exception {
+        // When:
+        final WildcardType wildcardType = TypeUtils.wildcardTypeWithUpperBounds();
+
+        // Then:
+        assertThat(wildcardType.getUpperBounds().length, is(1));
+        assertThat(wildcardType.getUpperBounds()[0], is(equalTo(Object.class)));
     }
 }

--- a/populace-core/src/test/java/org/datalorax/populace/core/walk/field/filter/AllFieldFilterTest.java
+++ b/populace-core/src/test/java/org/datalorax/populace/core/walk/field/filter/AllFieldFilterTest.java
@@ -16,6 +16,8 @@
 
 package org.datalorax.populace.core.walk.field.filter;
 
+import com.google.common.testing.EqualsTester;
+import com.google.common.testing.NullPointerTester;
 import org.datalorax.populace.core.walk.field.FieldInfo;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
@@ -42,11 +44,6 @@ public class AllFieldFilterTest {
         filter = new AllFieldFilter(first, second, third);
     }
 
-    @Test(expectedExceptions = NullPointerException.class)
-    public void shouldThrowIfAnyFilterIsNull() throws Exception {
-        new AllFieldFilter(first, null, third);
-    }
-
     @Test
     public void shouldExcludeIfAnyFilterExclude() throws Exception {
         // Given:
@@ -67,5 +64,23 @@ public class AllFieldFilterTest {
 
         // Then:
         assertThat(filter.include(field), is(true));
+    }
+
+    @Test
+    public void shouldTestEqualsAndHashCode() throws Exception {
+        new EqualsTester()
+            .addEqualityGroup(new AllFieldFilter(first, second, third), new AllFieldFilter(first, second, third))
+            .addEqualityGroup(new AllFieldFilter(first, second, third, mock(FieldFilter.class)))
+            .addEqualityGroup(new AllFieldFilter(first, second))
+            .addEqualityGroup(new AllFieldFilter(mock(FieldFilter.class), second, third))
+            .addEqualityGroup(new AllFieldFilter(first, mock(FieldFilter.class), third))
+            .testEquals();
+    }
+
+    @Test
+    public void shouldThrowNPEsOnConstructorParams() throws Exception {
+        new NullPointerTester()
+            .setDefault(FieldFilter.class, mock(FieldFilter.class))
+            .testAllPublicConstructors(AllFieldFilter.class);
     }
 }

--- a/populace-core/src/test/java/org/datalorax/populace/core/walk/field/filter/AndFieldFilterTest.java
+++ b/populace-core/src/test/java/org/datalorax/populace/core/walk/field/filter/AndFieldFilterTest.java
@@ -16,6 +16,8 @@
 
 package org.datalorax.populace.core.walk.field.filter;
 
+import com.google.common.testing.EqualsTester;
+import com.google.common.testing.NullPointerTester;
 import org.datalorax.populace.core.walk.field.FieldInfo;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
@@ -38,16 +40,6 @@ public class AndFieldFilterTest {
         field = mock(FieldInfo.class);
 
         filter = new AndFieldFilter(first, second);
-    }
-
-    @Test(expectedExceptions = NullPointerException.class)
-    public void shouldThrowIfFirstFilterIsNull() throws Exception {
-        new AndFieldFilter(null, second);
-    }
-
-    @Test(expectedExceptions = NullPointerException.class)
-    public void shouldThrowIfSecondFilterIsNull() throws Exception {
-        new AndFieldFilter(first, null);
     }
 
     @Test
@@ -88,5 +80,21 @@ public class AndFieldFilterTest {
 
         // Then:
         assertThat(filter.include(field), is(true));
+    }
+
+    @Test
+    public void shouldTestEqualsAndHashCode() throws Exception {
+        new EqualsTester()
+            .addEqualityGroup(new AndFieldFilter(first, second), new AndFieldFilter(first, second))
+            .addEqualityGroup(new AndFieldFilter(mock(FieldFilter.class), second))
+            .addEqualityGroup(new AndFieldFilter(first, mock(FieldFilter.class)))
+            .testEquals();
+    }
+
+    @Test
+    public void shouldThrowNPEsOnConstructorParams() throws Exception {
+        new NullPointerTester()
+            .setDefault(FieldFilter.class, mock(FieldFilter.class))
+            .testAllPublicConstructors(AndFieldFilter.class);
     }
 }

--- a/populace-core/src/test/java/org/datalorax/populace/core/walk/field/filter/AnyFieldFilterTest.java
+++ b/populace-core/src/test/java/org/datalorax/populace/core/walk/field/filter/AnyFieldFilterTest.java
@@ -16,6 +16,8 @@
 
 package org.datalorax.populace.core.walk.field.filter;
 
+import com.google.common.testing.EqualsTester;
+import com.google.common.testing.NullPointerTester;
 import org.datalorax.populace.core.walk.field.FieldInfo;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
@@ -42,11 +44,6 @@ public class AnyFieldFilterTest {
         filter = new AnyFieldFilter(first, second, third);
     }
 
-    @Test(expectedExceptions = NullPointerException.class)
-    public void shouldThrowIfAnyFilterIsNull() throws Exception {
-        new AnyFieldFilter(first, null, third);
-    }
-
     @Test
     public void shouldExcludeOnlyIfAllExclude() throws Exception {
         // Given:
@@ -67,5 +64,23 @@ public class AnyFieldFilterTest {
 
         // Then:
         assertThat(filter.include(field), is(true));
+    }
+
+    @Test
+    public void shouldTestEqualsAndHashCode() throws Exception {
+        new EqualsTester()
+            .addEqualityGroup(new AnyFieldFilter(first, second, third), new AnyFieldFilter(first, second, third))
+            .addEqualityGroup(new AnyFieldFilter(first, second, third, mock(FieldFilter.class)))
+            .addEqualityGroup(new AnyFieldFilter(first, second))
+            .addEqualityGroup(new AnyFieldFilter(mock(FieldFilter.class), second, third))
+            .addEqualityGroup(new AnyFieldFilter(first, mock(FieldFilter.class), third))
+            .testEquals();
+    }
+
+    @Test
+    public void shouldThrowNPEsOnConstructorParams() throws Exception {
+        new NullPointerTester()
+            .setDefault(FieldFilter.class, mock(FieldFilter.class))
+            .testAllPublicConstructors(AnyFieldFilter.class);
     }
 }

--- a/populace-core/src/test/java/org/datalorax/populace/core/walk/field/filter/ExcludeFinalFieldsFilterTest.java
+++ b/populace-core/src/test/java/org/datalorax/populace/core/walk/field/filter/ExcludeFinalFieldsFilterTest.java
@@ -16,6 +16,7 @@
 
 package org.datalorax.populace.core.walk.field.filter;
 
+import com.google.common.testing.EqualsTester;
 import org.datalorax.populace.core.walk.field.FieldInfo;
 import org.testng.annotations.Test;
 
@@ -43,5 +44,13 @@ public class ExcludeFinalFieldsFilterTest {
 
         // Then:
         assertThat(ExcludeFinalFieldsFilter.INSTANCE.include(fieldInfo), is(true));
+    }
+
+    @Test
+    public void shouldTestEqualsAndHashCode() throws Exception {
+        new EqualsTester()
+            .addEqualityGroup(ExcludeFinalFieldsFilter.INSTANCE, new ExcludeFinalFieldsFilter())
+            .addEqualityGroup(mock(FieldFilter.class))
+            .testEquals();
     }
 }

--- a/populace-core/src/test/java/org/datalorax/populace/core/walk/field/filter/ExcludeStaticFieldsFilterTest.java
+++ b/populace-core/src/test/java/org/datalorax/populace/core/walk/field/filter/ExcludeStaticFieldsFilterTest.java
@@ -16,6 +16,7 @@
 
 package org.datalorax.populace.core.walk.field.filter;
 
+import com.google.common.testing.EqualsTester;
 import org.datalorax.populace.core.walk.field.FieldInfo;
 import org.testng.annotations.Test;
 
@@ -43,5 +44,13 @@ public class ExcludeStaticFieldsFilterTest {
 
         // Then:
         assertThat(ExcludeStaticFieldsFilter.INSTANCE.include(fieldInfo), is(true));
+    }
+
+    @Test
+    public void shouldTestEqualsAndHashCode() throws Exception {
+        new EqualsTester()
+            .addEqualityGroup(ExcludeStaticFieldsFilter.INSTANCE, new ExcludeStaticFieldsFilter())
+            .addEqualityGroup(mock(FieldFilter.class))
+            .testEquals();
     }
 }

--- a/populace-core/src/test/java/org/datalorax/populace/core/walk/field/filter/ExcludeTransientFieldsFilterTest.java
+++ b/populace-core/src/test/java/org/datalorax/populace/core/walk/field/filter/ExcludeTransientFieldsFilterTest.java
@@ -16,6 +16,7 @@
 
 package org.datalorax.populace.core.walk.field.filter;
 
+import com.google.common.testing.EqualsTester;
 import org.datalorax.populace.core.walk.field.FieldInfo;
 import org.testng.annotations.Test;
 
@@ -43,5 +44,13 @@ public class ExcludeTransientFieldsFilterTest {
 
         // Then:
         assertThat(ExcludeTransientFieldsFilter.INSTANCE.include(fieldInfo), is(true));
+    }
+
+    @Test
+    public void shouldTestEqualsAndHashCode() throws Exception {
+        new EqualsTester()
+            .addEqualityGroup(ExcludeTransientFieldsFilter.INSTANCE, new ExcludeTransientFieldsFilter())
+            .addEqualityGroup(mock(FieldFilter.class))
+            .testEquals();
     }
 }

--- a/populace-core/src/test/java/org/datalorax/populace/core/walk/field/filter/FieldFiltersTest.java
+++ b/populace-core/src/test/java/org/datalorax/populace/core/walk/field/filter/FieldFiltersTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2015 Andrew Coates
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.datalorax.populace.core.walk.field.filter;
+
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.Mockito.mock;
+
+public class FieldFiltersTest {
+    private FieldFilter filter1;
+    private FieldFilter filter2;
+    private FieldFilter filter3;
+
+    @BeforeMethod
+    public void setUp() throws Exception {
+        filter1 = mock(FieldFilter.class, "1");
+        filter2 = mock(FieldFilter.class, "2");
+        filter3 = mock(FieldFilter.class, "3");
+    }
+
+    @Test
+    public void shouldReturnDefaults() throws Exception {
+        assertThat(FieldFilters.defaults(), is(new AndFieldFilter(ExcludeStaticFieldsFilter.INSTANCE, ExcludeTransientFieldsFilter.INSTANCE)));
+    }
+
+    @Test
+    public void shouldReturnAndFilter() throws Exception {
+        assertThat(FieldFilters.and(filter1, filter2), is(new AndFieldFilter(filter1, filter2)));
+    }
+
+    @Test
+    public void shouldReturnOrFilter() throws Exception {
+        assertThat(FieldFilters.or(filter1, filter2), is(new OrFieldFilter(filter1, filter2)));
+    }
+
+    @Test
+    public void shouldReturnAllFilter() throws Exception {
+        assertThat(FieldFilters.all(filter1, filter2, filter3), is(new AllFieldFilter(filter1, filter2, filter3)));
+    }
+
+    @Test
+    public void shouldReturnAnyFilter() throws Exception {
+        assertThat(FieldFilters.any(filter1, filter2, filter3), is(new AnyFieldFilter(filter1, filter2, filter3)));
+    }
+
+    @Test
+    public void shouldReturnOnlyFilterFromAny() throws Exception {
+        assertThat(FieldFilters.any(filter1), is(filter1));
+    }
+
+    @Test
+    public void shouldReturnOnlyFilterFromAll() throws Exception {
+        assertThat(FieldFilters.all(filter1), is(filter1));
+    }
+}

--- a/populace-core/src/test/java/org/datalorax/populace/core/walk/field/filter/OrFieldFilterTest.java
+++ b/populace-core/src/test/java/org/datalorax/populace/core/walk/field/filter/OrFieldFilterTest.java
@@ -16,6 +16,8 @@
 
 package org.datalorax.populace.core.walk.field.filter;
 
+import com.google.common.testing.EqualsTester;
+import com.google.common.testing.NullPointerTester;
 import org.datalorax.populace.core.walk.field.FieldInfo;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
@@ -33,21 +35,11 @@ public class OrFieldFilterTest {
 
     @BeforeMethod
     public void setUp() throws Exception {
-        first = mock(FieldFilter.class);
-        second = mock(FieldFilter.class);
+        first = mock(FieldFilter.class, "first");
+        second = mock(FieldFilter.class, "second");
         field = mock(FieldInfo.class);
 
         filter = new OrFieldFilter(first, second);
-    }
-
-    @Test(expectedExceptions = NullPointerException.class)
-    public void shouldThrowIfFirstFilterIsNull() throws Exception {
-        new OrFieldFilter(null, second);
-    }
-
-    @Test(expectedExceptions = NullPointerException.class)
-    public void shouldThrowIfSecondFilterIsNull() throws Exception {
-        new OrFieldFilter(first, null);
     }
 
     @Test
@@ -88,5 +80,21 @@ public class OrFieldFilterTest {
 
         // Then:
         assertThat(filter.include(field), is(true));
+    }
+
+    @Test
+    public void shouldTestEqualsAndHashCode() throws Exception {
+        new EqualsTester()
+            .addEqualityGroup(new OrFieldFilter(first, second), new OrFieldFilter(first, second))
+            .addEqualityGroup(new OrFieldFilter(mock(FieldFilter.class), second))
+            .addEqualityGroup(new OrFieldFilter(first, mock(FieldFilter.class)))
+            .testEquals();
+    }
+
+    @Test
+    public void shouldThrowNPEsOnConstructorParams() throws Exception {
+        new NullPointerTester()
+            .setDefault(FieldFilter.class, mock(FieldFilter.class))
+            .testAllPublicConstructors(OrFieldFilter.class);
     }
 }

--- a/populace-core/src/test/java/org/datalorax/populace/core/walk/inspector/CollectionInspectorTest.java
+++ b/populace-core/src/test/java/org/datalorax/populace/core/walk/inspector/CollectionInspectorTest.java
@@ -16,6 +16,7 @@
 
 package org.datalorax.populace.core.walk.inspector;
 
+import com.google.common.testing.EqualsTester;
 import org.datalorax.populace.core.CustomCollection;
 import org.datalorax.populace.core.walk.element.RawElement;
 import org.testng.annotations.BeforeMethod;
@@ -25,17 +26,10 @@ import java.util.*;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
+import static org.mockito.Mockito.mock;
 
 public class CollectionInspectorTest {
     private CollectionInspector inspector;
-
-    private static List<RawElement> collectAll(Iterator<RawElement> it) {
-        final List<RawElement> elements = new ArrayList<>();
-        while (it.hasNext()) {
-            elements.add(it.next());
-        }
-        return elements;
-    }
 
     @BeforeMethod
     public void setUp() throws Exception {
@@ -103,5 +97,24 @@ public class CollectionInspectorTest {
 
         // Then:
         assertThat(elements.get(0).getValue(), is(nullValue()));
+    }
+
+    @Test
+    public void shouldTestEqualsAndHashCode() throws Exception {
+        new EqualsTester()
+            .addEqualityGroup(
+                CollectionInspector.INSTANCE,
+                new CollectionInspector())
+            .addEqualityGroup(
+                mock(Inspector.class))
+            .testEquals();
+    }
+
+    private static List<RawElement> collectAll(Iterator<RawElement> it) {
+        final List<RawElement> elements = new ArrayList<>();
+        while (it.hasNext()) {
+            elements.add(it.next());
+        }
+        return elements;
     }
 }

--- a/populace-core/src/test/java/org/datalorax/populace/core/walk/inspector/FieldInspectorTest.java
+++ b/populace-core/src/test/java/org/datalorax/populace/core/walk/inspector/FieldInspectorTest.java
@@ -16,6 +16,7 @@
 
 package org.datalorax.populace.core.walk.inspector;
 
+import com.google.common.testing.EqualsTester;
 import org.datalorax.populace.core.walk.field.RawField;
 import org.datalorax.populace.core.walk.inspector.annotation.AnnotationInspector;
 import org.testng.annotations.BeforeMethod;
@@ -113,5 +114,16 @@ public class FieldInspectorTest {
 
         // Then:
         assertThat("should not have field containing reference to outer class", fields.iterator().hasNext(), is(false));
+    }
+
+    @Test
+    public void shouldTestEqualsAndHashCode() throws Exception {
+        new EqualsTester()
+            .addEqualityGroup(
+                FieldInspector.INSTANCE,
+                new FieldInspector())
+            .addEqualityGroup(
+                mock(Inspector.class))
+            .testEquals();
     }
 }

--- a/populace-core/src/test/java/org/datalorax/populace/core/walk/inspector/InspectorsTest.java
+++ b/populace-core/src/test/java/org/datalorax/populace/core/walk/inspector/InspectorsTest.java
@@ -1,0 +1,237 @@
+/*
+ * Copyright (c) 2015 Andrew Coates
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.datalorax.populace.core.walk.inspector;
+
+import com.google.common.testing.EqualsTester;
+import com.google.common.testing.NullPointerTester;
+import org.datalorax.populace.core.util.ImmutableTypeMap;
+import org.datalorax.populace.core.util.TypeUtils;
+import org.datalorax.populace.core.walk.inspector.annotation.AnnotationInspector;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.lang.reflect.Type;
+import java.math.BigDecimal;
+import java.util.Collection;
+import java.util.Optional;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+import static org.mockito.Mockito.mock;
+
+public class InspectorsTest {
+    private Inspectors.Builder builder;
+    private Inspectors inspectors;
+
+    @BeforeMethod
+    public void setUp() throws Exception {
+        builder = Inspectors.newBuilder();
+        inspectors = builder.build();
+    }
+
+    @Test
+    public void shouldHaveDefaultInspector() throws Exception {
+        // When:
+        final Inspector factory = inspectors.getDefault();
+
+        // Then:
+        assertThat(factory, is(notNullValue()));
+    }
+
+    @Test
+    public void shouldReturnDefaultInspectorForUnregisteredNonArrayType() throws Exception {
+        // Given:
+        final Type unregisteredType = getClass();
+
+        // When:
+        final Inspector factory = inspectors.get(unregisteredType);
+
+        // Then:
+        assertThat(factory, is(inspectors.getDefault()));
+    }
+
+    @Test
+    public void shouldBeAbleToOverrideTheDefault() throws Exception {
+        // Given:
+        final Inspector newDefaultInspector = mock(Inspector.class, "default");
+
+        // When:
+        final Inspectors inspectors = builder
+            .withDefaultInspector(newDefaultInspector)
+            .build();
+
+        // Then:
+        assertThat(inspectors.getDefault(), is(newDefaultInspector));
+    }
+
+    @Test
+    public void shouldHaveDefaultArrayInspector() throws Exception {
+        // Given:
+        final Type arrayType = TypeUtils.genericArrayType(int.class);
+
+        // When:
+        final Inspector factory = inspectors.get(arrayType);
+
+        // Then:
+        assertThat(factory, is(notNullValue()));
+    }
+
+    @Test
+    public void shouldReturnDefaultArrayInspectorIfArrayTypeNotRegistered() throws Exception {
+        // Given:
+        final Type unregistered = TypeUtils.genericArrayType(int.class);
+
+        // When:
+        final Inspector factory = inspectors.get(unregistered);
+
+        // Then:
+        assertThat(factory, is(inspectors.getArrayDefault()));
+    }
+
+    @Test
+    public void shouldBeAbleToOverrideDefaultArrayInspector() throws Exception {
+        // Given:
+        final Inspector newDefaultInspector = mock(Inspector.class, "array default");
+
+        // When:
+        final Inspectors inspectors = builder
+            .withArrayDefaultInspector(newDefaultInspector)
+            .build();
+
+        // Then:
+        assertThat(inspectors.getArrayDefault(), is(newDefaultInspector));
+    }
+
+    @Test
+    public void shouldReturnNotPresentFromGetSpecificIfNoSpecificRegistered() throws Exception {
+        // Given:
+        final Type unregistered = TypeUtils.parameterise(Collection.class, Integer.class);
+
+        // When:
+        final Optional<Inspector> factory = inspectors.getSpecific(unregistered);
+
+        // Then:
+        assertThat(factory, is(Optional.<Inspector>empty()));
+    }
+
+    @Test
+    public void shouldReturnSpecificInspectorFromGetSpecificIfRegistered() throws Exception {
+        // Given:
+        final Inspector expected = mock(Inspector.class);
+        final Type registered = TypeUtils.parameterise(Collection.class, Integer.class);
+        inspectors = builder.withSpecificInspector(registered, expected).build();
+
+        // When:
+        final Optional<Inspector> factory = inspectors.getSpecific(registered);
+
+        // Then:
+        assertThat(factory, is(Optional.of(expected)));
+    }
+
+    @Test
+    public void shouldReturnNotPresentFromGetSuperIfNoSuperRegistered() throws Exception {
+        // When:
+        final Optional<Inspector> factory = inspectors.getSuper(String.class);
+
+        // Then:
+        assertThat(factory, is(Optional.<Inspector>empty()));
+    }
+
+    @Test
+    public void shouldReturnSuperInspectorFromGetSuperIfRegistered() throws Exception {
+        // Given:
+        final Inspector expected = mock(Inspector.class);
+        inspectors = builder.withSuperInspector(String.class, expected).build();
+
+        // When:
+        final Optional<Inspector> factory = inspectors.getSuper(String.class);
+
+        // Then:
+        assertThat(factory, is(Optional.of(expected)));
+    }
+
+    @Test
+    public void shouldReturnNotPresentFromGetPackageIfNoPackageRegistered() throws Exception {
+        // When:
+        final Optional<Inspector> factory = inspectors.getPackage("some.package");
+
+        // Then:
+        assertThat(factory, is(Optional.<Inspector>empty()));
+    }
+
+    @Test
+    public void shouldReturnPackageInspectorFromGetPackageIfRegistered() throws Exception {
+        // Given:
+        final Inspector expected = mock(Inspector.class);
+        inspectors = builder.withPackageInspector("some.package", expected).build();
+
+        // When:
+        final Optional<Inspector> factory = inspectors.getPackage("some.package");
+
+        // Then:
+        assertThat(factory, is(Optional.of(expected)));
+    }
+
+    @Test
+    public void shouldSupportSpecificInspectorForBigDecimal() throws Exception {
+        // When:
+        final Inspector factory = inspectors.get(BigDecimal.class);
+
+        // Then:
+        assertThat(factory, is(not(inspectors.getDefault())));
+    }
+
+    @Test
+    public void shouldGetInspectorForNonClassOrParameterizedTypeIfSpecificRegistered() throws Exception {
+        // Given:
+        final Type wildcardType = TypeUtils.wildcardType();
+        final Inspector factory = mock(Inspector.class, "specific");
+
+        // When:
+        final Inspectors inspectors = builder
+            .withSpecificInspector(wildcardType, factory)
+            .build();
+
+        // Then:
+        assertThat(inspectors.get(wildcardType), is(factory));
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void shouldTestEqualsAndHashCode() throws Exception {
+        final ImmutableTypeMap<Inspector> rawInspectors = mock(ImmutableTypeMap.class, "1");
+        final AnnotationInspector annotationInspector = mock(AnnotationInspector.class, "1");
+
+        new EqualsTester()
+            .addEqualityGroup(
+                new Inspectors(rawInspectors, annotationInspector),
+                new Inspectors(rawInspectors, annotationInspector))
+            .addEqualityGroup(
+                new Inspectors(mock(ImmutableTypeMap.class, "2"), annotationInspector))
+            .addEqualityGroup(
+                new Inspectors(rawInspectors, mock(AnnotationInspector.class, "2")))
+            .testEquals();
+    }
+
+    @Test
+    public void shouldThrowNPEsOnConstructorParams() throws Exception {
+        new NullPointerTester()
+            .setDefault(ImmutableTypeMap.class, mock(ImmutableTypeMap.class))
+            .setDefault(AnnotationInspector.class, mock(AnnotationInspector.class))
+            .testAllPublicConstructors(Inspectors.class);
+    }
+}

--- a/populace-core/src/test/java/org/datalorax/populace/core/walk/inspector/SetInspectorTest.java
+++ b/populace-core/src/test/java/org/datalorax/populace/core/walk/inspector/SetInspectorTest.java
@@ -16,6 +16,7 @@
 
 package org.datalorax.populace.core.walk.inspector;
 
+import com.google.common.testing.EqualsTester;
 import org.datalorax.populace.core.walk.element.RawElement;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
@@ -24,17 +25,10 @@ import java.util.*;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
+import static org.mockito.Mockito.mock;
 
 public class SetInspectorTest {
     private SetInspector inspector;
-
-    private static List<RawElement> collectAll(Iterator<RawElement> it) {
-        final List<RawElement> elements = new ArrayList<>();
-        while (it.hasNext()) {
-            elements.add(it.next());
-        }
-        return elements;
-    }
 
     @BeforeMethod
     public void setUp() throws Exception {
@@ -199,5 +193,24 @@ public class SetInspectorTest {
         // Then:
         assertThat(element.getValue(), is(nullValue()));
         assertThat(set, contains(nullValue()));
+    }
+
+    @Test
+    public void shouldTestEqualsAndHashCode() throws Exception {
+        new EqualsTester()
+            .addEqualityGroup(
+                SetInspector.INSTANCE,
+                new SetInspector())
+            .addEqualityGroup(
+                mock(Inspector.class))
+            .testEquals();
+    }
+
+    private static List<RawElement> collectAll(Iterator<RawElement> it) {
+        final List<RawElement> elements = new ArrayList<>();
+        while (it.hasNext()) {
+            elements.add(it.next());
+        }
+        return elements;
     }
 }

--- a/populace-core/src/test/java/org/datalorax/populace/core/walk/inspector/TerminalInspectorTest.java
+++ b/populace-core/src/test/java/org/datalorax/populace/core/walk/inspector/TerminalInspectorTest.java
@@ -16,10 +16,12 @@
 
 package org.datalorax.populace.core.walk.inspector;
 
+import com.google.common.testing.EqualsTester;
 import org.testng.annotations.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.mockito.Mockito.mock;
 
 public class TerminalInspectorTest {
     @Test
@@ -30,6 +32,17 @@ public class TerminalInspectorTest {
     @Test
     public void shouldReturnNoChildren() throws Exception {
         assertThat(TerminalInspector.INSTANCE.getElements(new SomeType(), null).hasNext(), is(false));
+    }
+
+    @Test
+    public void shouldTestEqualsAndHashCode() throws Exception {
+        new EqualsTester()
+            .addEqualityGroup(
+                TerminalInspector.INSTANCE,
+                new TerminalInspector())
+            .addEqualityGroup(
+                mock(Inspector.class))
+            .testEquals();
     }
 
     @SuppressWarnings("UnusedDeclaration")

--- a/populace-module-jaxb-annotations/src/test/java/org/datalorax/populace/jaxb/field/filter/ExcludeXmlTransientFieldsTest.java
+++ b/populace-module-jaxb-annotations/src/test/java/org/datalorax/populace/jaxb/field/filter/ExcludeXmlTransientFieldsTest.java
@@ -16,7 +16,9 @@
 
 package org.datalorax.populace.jaxb.field.filter;
 
+import com.google.common.testing.EqualsTester;
 import org.datalorax.populace.core.walk.field.FieldInfo;
+import org.datalorax.populace.core.walk.field.filter.FieldFilter;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
@@ -76,6 +78,14 @@ public class ExcludeXmlTransientFieldsTest {
 
         // Then:
         assertThat(filter.include(field), is(true));
+    }
+
+    @Test
+    public void shouldTestEqualsAndHashCode() throws Exception {
+        new EqualsTester()
+            .addEqualityGroup(ExcludeXmlTransientFields.INSTANCE, new ExcludeXmlTransientFields())
+            .addEqualityGroup(mock(FieldFilter.class))
+            .testEquals();
     }
 
     private void givenFieldNotMarkedTransient() {


### PR DESCRIPTION
Guava test utils introduced to give test coverage of `equals`, `hashCode` and any non-nullable constructor parameters.

(Please some javadoc improvements)
