### PR TITLE
#Pop-55 Don't propagate toString() exceptions

### DIFF
--- a/populace-core/src/main/java/org/datalorax/populace/core/util/ObjectUtils.java
+++ b/populace-core/src/main/java/org/datalorax/populace/core/util/ObjectUtils.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2015 Andrew Coates
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.datalorax.populace.core.util;
+
+/**
+ * @author Andrew Coates - 11/05/2015.
+ */
+public class ObjectUtils {
+    public static String safeToString(final Object object) {
+        try {
+            return object == null ? "null" : object.toString();
+        } catch (RuntimeException e) {
+            return e.getClass().toString() + " thrown from toString()";
+        }
+    }
+}

--- a/populace-core/src/main/java/org/datalorax/populace/core/walk/element/ElementInfo.java
+++ b/populace-core/src/main/java/org/datalorax/populace/core/walk/element/ElementInfo.java
@@ -17,6 +17,7 @@
 package org.datalorax.populace.core.walk.element;
 
 import org.apache.commons.lang3.Validate;
+import org.datalorax.populace.core.util.ObjectUtils;
 import org.datalorax.populace.core.util.TypeResolver;
 import org.datalorax.populace.core.walk.field.PathProvider;
 
@@ -87,7 +88,7 @@ public class ElementInfo {
     @Override
     public String toString() {
         return "ElementInfo{" +
-            "element=" + element +
+            "element=" + ObjectUtils.safeToString(element) +
             ", typeResolver=" + typeResolver +
             ", path=" + path +
             '}';

--- a/populace-core/src/main/java/org/datalorax/populace/core/walk/field/FieldInfo.java
+++ b/populace-core/src/main/java/org/datalorax/populace/core/walk/field/FieldInfo.java
@@ -17,6 +17,7 @@
 package org.datalorax.populace.core.walk.field;
 
 import org.apache.commons.lang3.Validate;
+import org.datalorax.populace.core.util.ObjectUtils;
 import org.datalorax.populace.core.util.TypeResolver;
 
 import java.lang.annotation.Annotation;
@@ -85,6 +86,7 @@ public class FieldInfo {
      * <li>For <b>non-primitive types with a null value</b> this method returns the resolved generic type of the field</li>
      * <li>For <b>non-primitive types with a non-null value</b> this method returns the resolved generic type of the value</li>
      * </ul>
+     *
      * @return the generic type of the field
      * @see RawField#getGenericType()
      */
@@ -198,8 +200,8 @@ public class FieldInfo {
     @Override
     public String toString() {
         return "FieldInfo{" +
-            "field=" + field +
-            ", owningInstance=" + owningInstance +
+            "field=" + ObjectUtils.safeToString(field) +
+            ", owningInstance=" + ObjectUtils.safeToString(owningInstance) +
             ", typeResolver=" + typeResolver +
             ", path=" + pathProvider.getPath() +
             '}';

--- a/populace-core/src/test/java/org/datalorax/populace/core/util/ObjectUtilsTest.java
+++ b/populace-core/src/test/java/org/datalorax/populace/core/util/ObjectUtilsTest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2015 Andrew Coates
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.datalorax.populace.core.util;
+
+import org.testng.annotations.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class ObjectUtilsTest {
+    @Test
+    public void shouldReturnToString() throws Exception {
+        assertThat(ObjectUtils.safeToString("value"), is("value"));
+    }
+
+    @Test
+    public void shouldSwallowException() throws Exception {
+        // Given:
+        final Object mock = mock(Object.class);
+        when(mock.toString()).thenThrow(new RuntimeException("BANG"));
+
+        // When:
+        final String result = ObjectUtils.safeToString(mock);
+
+        // Then:
+        // Didn't go pop!
+        assertThat(result, containsString("RuntimeException"));
+    }
+}

--- a/populace-core/src/test/java/org/datalorax/populace/core/walk/element/ElementInfoTest.java
+++ b/populace-core/src/test/java/org/datalorax/populace/core/walk/element/ElementInfoTest.java
@@ -28,8 +28,7 @@ import java.util.List;
 import java.util.Set;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.*;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.*;
 
@@ -95,6 +94,19 @@ public class ElementInfoTest {
 
         // Then:
         verify(element).setValue(newValue);
+    }
+
+    @Test
+    public void shouldNotPropagateRawElementToStringExceptions() throws Exception {
+        // Given:
+        when(element.toString()).thenThrow(new RuntimeException("BANG!"));
+
+        // When:
+        final String string = elementInfo.toString();
+
+        // Then:
+        // Didn't go pop!
+        assertThat(string, is(not("")));
     }
 
     @Test

--- a/populace-core/src/test/java/org/datalorax/populace/core/walk/field/FieldInfoTest.java
+++ b/populace-core/src/test/java/org/datalorax/populace/core/walk/field/FieldInfoTest.java
@@ -376,6 +376,32 @@ public class FieldInfoTest {
             .testAllPublicConstructors(FieldInfo.class);
     }
 
+    @Test
+    public void shouldNotPropagateOwningInstanceToStringExceptions() throws Exception {
+        // Given:
+        when(owningInstance.toString()).thenThrow(new RuntimeException("BANG!"));
+
+        // When:
+        final String string = fieldInfo.toString();
+
+        // Then:
+        // Didn't go pop!
+        assertThat(string, is(not("")));
+    }
+
+    @Test
+    public void shouldNotPropagateRawFieldToStringExceptions() throws Exception {
+        // Given:
+        when(field.toString()).thenThrow(new RuntimeException("BANG!"));
+
+        // When:
+        final String string = fieldInfo.toString();
+
+        // Then:
+        // Didn't go pop!
+        assertThat(string, is(not("")));
+    }
+
     private void givenFieldHasValue(final Object value) throws IllegalAccessException {
         givenFieldHasValue(value, value.getClass());
     }


### PR DESCRIPTION
Don't propagate toString() exceptions from client code, (as i…t may be outside their control to fix).

Fixes #Pop-55
